### PR TITLE
Remove disable-model-invocation to allow Claude to self-invoke the skill

### DIFF
--- a/skills/comprehensive-review/SKILL.md
+++ b/skills/comprehensive-review/SKILL.md
@@ -21,7 +21,6 @@ allowed-tools:
   - mcp__github-pat__get_pull_request
   - mcp__github-pat__search_issues
   - mcp__github-pat__search_code
-disable-model-invocation: true
 ---
 
 # Comprehensive PR Review


### PR DESCRIPTION
## Summary

Removes `disable-model-invocation: true` from the skill frontmatter, allowing Claude to invoke `/comprehensive-review` programmatically via the `Skill` tool. This unblocks the intended dogfooding workflow where Claude automatically runs the skill before opening pull requests on this repo.

**Type:** bugfix
**Effort:** 1/5 — Single line deletion

## Walkthrough

| File | Change | Summary |
|------|--------|---------|
| `skills/comprehensive-review/SKILL.md` | Modified | Removed `disable-model-invocation: true` from frontmatter |

## Why this is safe

The flag is documented for skills with destructive side effects (deploy, commit, migrations). This skill's only side effects are posting PR descriptions/comments via `gh` — low-risk and idempotent. There is zero recursive invocation risk: `Skill` is not in the `allowed-tools` list, so no sub-agent spawned by this skill can invoke it again.

Closes #1