### PR TITLE
Add inline PR review posting, external PR review mode, --help, expanded --quick

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ Both blocks are always shown locally. What gets posted to GitHub depends on cont
 | Existing own PR + `--post-findings` | Not posted | Inline GitHub review (`COMMENT` event) |
 | `--pr <N>` mode (default) | Not posted | Inline GitHub review (`REQUEST_CHANGES` if Medium+, `COMMENT` if Low) |
 | `--pr <N>` + `--post-summary` | PR comment | Inline GitHub review |
+| `--pr <N>` + `--no-findings` | Not posted | Not posted |
 | Any + `--no-post`/`--local` | Not posted | Not posted |
 
 The key invariant: Block A is auto-posted only when *creating* a new PR. On existing PRs, both blocks require explicit opt-in flags. Block B is never hidden from the terminal.

--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ Run from any git repository, on the branch you want to review:
 # Review PR #42 and also post the summary as a comment
 /comprehensive-review --pr 42 --post-summary
 
-# Dry-run: review PR #42 locally before posting anything
-/comprehensive-review --pr 42 --no-findings --no-post
+# Dry-run: review PR #42 locally, skip the findings review post
+/comprehensive-review --pr 42 --no-findings
 
 # Review against a non-default base
 /comprehensive-review --base develop

--- a/skills/comprehensive-review/SKILL.md
+++ b/skills/comprehensive-review/SKILL.md
@@ -65,6 +65,8 @@ Supported flags:
    - Extract `--pr <number>` if present — set PR_NUMBER and enable external review mode
    - Note mode flags: `--quick`, `--security-only`, `--summary-only`, `--no-post`/`--local`,
      `--post-summary`, `--post-findings`, `--no-findings`
+   - **Flag conflict check:** if both `--post-findings` and `--no-findings` are present, report
+     "Error: --post-findings and --no-findings are mutually exclusive." and stop.
 
 **Help text (display when `--help` is passed):**
 
@@ -115,7 +117,7 @@ Examples
   /comprehensive-review --post-findings         Review + post findings on existing own PR
   /comprehensive-review --pr 42                 Review someone else's PR #42
   /comprehensive-review --pr 42 --post-summary  Review PR #42 and also post summary comment
-  /comprehensive-review --pr 42 --no-findings   Review PR #42 locally (dry run)
+  /comprehensive-review --pr 42 --no-findings   Review PR #42 locally, skip findings post
   /comprehensive-review --no-post               Review locally, skip all GitHub operations
 ```
 
@@ -131,8 +133,15 @@ Examples
       ```bash
       WORKTREE_PATH=$(mktemp -d /tmp/cr-pr-XXXXXXXX)
       rmdir "$WORKTREE_PATH"   # mktemp creates the dir; worktree add needs it absent
-      git worktree add "$WORKTREE_PATH" --detach
-      (cd "$WORKTREE_PATH" && gh pr checkout <N>)
+      git worktree add "$WORKTREE_PATH" --detach || {
+        echo "Error: failed to create worktree at $WORKTREE_PATH" >&2
+        exit 1
+      }
+      (cd "$WORKTREE_PATH" && gh pr checkout <N>) || {
+        git worktree remove "$WORKTREE_PATH" --force 2>/dev/null
+        echo "Error: failed to check out PR #<N> into worktree" >&2
+        exit 1
+      }
       ```
       Track WORKTREE_PATH for cleanup in Phase 5.
    e. All subsequent `git diff`, `git log`, and `git show` commands in this workflow must use
@@ -142,6 +151,8 @@ Examples
    The actual diff and branch context come from the worktree.
 
 3. Run `git diff --name-only <base>...HEAD` to confirm the changed file list.
+   In `--pr` mode, prefix with `git -C "$WORKTREE_PATH"`: `git -C "$WORKTREE_PATH" diff --name-only <base>...HEAD`
+   All `git diff`, `git log`, and `git show` commands from this point forward use `git -C "$WORKTREE_PATH"` in `--pr` mode.
 
 4. If there are no changed files, report "No changes found between current branch and `<base>`" and stop.
 
@@ -449,6 +460,10 @@ Else (own-branch mode):
     PR_EXISTS = false
     POST_SUMMARY = false  (creating the PR IS posting the summary)
     POST_FINDINGS = false  (never post findings on new PR creation)
+    If --post-findings was passed, warn: "Note: --post-findings has no effect when no PR exists.
+    Findings will be shown locally. Create a PR first, then re-run with --post-findings."
+    If --post-summary was passed, warn: "Note: --post-summary has no effect when no PR exists.
+    The summary will be used as the new PR's description."
 
   If command fails for any other reason (auth, network, permissions):
     Report "GitHub API error: <error>. Use --no-post to skip GitHub operations." and skip Phase 4.
@@ -482,7 +497,6 @@ gh pr comment <PR_NUMBER> --body "$(cat <<'CEOF'
 CEOF
 )"
 ```
-Note: for own-branch mode on an existing PR, `gh pr comment` (without specifying number) also works.
 
 ### Phase 4b: Post Findings as Inline Review
 


### PR DESCRIPTION
## Summary

Adds four new capabilities to the `/comprehensive-review` skill, transforming it from a local analysis tool into a full CodeRabbit-style inline review system.

**Type:** Feature
**Effort:** 4/5 — Major orchestration changes across all phases; new GitHub API integration; three-tier agent model restructure

## Walkthrough

| File | Change | Summary |
|------|--------|---------|
| `skills/comprehensive-review/SKILL.md` | Modified (+340/-85) | Complete orchestration rewrite: --help early exit, worktree setup for --pr mode, three-tier agent roster, structured findings data model, new Phase 4 posting matrix, new Phase 4b inline review posting, Phase 5 cleanup |
| `README.md` | Modified (+90/-15) | New comparison table vs pr-review-toolkit, updated flags table, posting behavior matrix, --quick mode roster, external PR review section |
| `CLAUDE.md` | Modified (+40/-2) | Updated two-block output design with conditional posting table, three-tier agent model docs, external review mode section, editing guidelines for --quick maintenance |

## What's new

### `--help` flag
Early exit with a comprehensive usage guide covering all flags, default behavior, agent rosters for full and quick modes, and examples.

### Inline review comments (`--post-findings`, `--post-summary`)
Findings can now be posted as inline GitHub PR review comments. The skill:
- Parses hunk headers to determine valid diff line targets
- Partitions findings into inline (file+line in diff) vs. review body (no line or line not in diff)
- Caps inline comments at 25 (top by severity); overflow goes to review body
- Uses `COMMENT` event on own PRs; `REQUEST_CHANGES` if Medium+ on external PRs
- Submits via `mcp__github-pat__create_pull_request_review` with `gh api` fallback

New flags: `--post-findings`, `--post-summary`, `--no-findings`

New posting behavior matrix (Block A auto-posts only on new PR creation; everything else is opt-in):

| Scenario | Block A | Block B |
|----------|---------|---------|
| No PR exists | PR description | Terminal only |
| Existing own PR | Terminal only | Terminal only |
| Own PR + `--post-summary` | PR comment | Terminal only |
| Own PR + `--post-findings` | Terminal only | Inline review (`COMMENT`) |
| `--pr <N>` (default) | Terminal only | Inline review (`REQUEST_CHANGES` if Medium+) |
| `--pr <N>` + `--post-summary` | PR comment | Inline review |
| `--pr <N>` + `--no-findings` | Terminal only | Terminal only |
| `--no-post` / `--local` | Terminal only | Terminal only |

### External PR review mode (`--pr <N>`)
Review any accessible PR by number — CodeRabbit-style:
1. Fetches PR metadata (`baseRefName`, `headRefName`, state)
2. Creates a temporary worktree and checks out the PR branch
3. Runs the full analysis pipeline against the worktree
4. Posts findings as an inline GitHub review by default
5. Cleans up the worktree in Phase 5

Includes error recovery: if worktree creation or `gh pr checkout` fails, the worktree is removed before reporting the error.

### Expanded `--quick` mode (~65% cost reduction)
Previous `--quick` only skipped issue-linker (1 Sonnet agent). The three Opus agents dominate cost. New `--quick` skips:
- `architecture-reviewer` (Opus)
- `security-reviewer` (Opus)
- `comment-analyzer`
- `type-design-analyzer`
- `issue-linker`

Keeps: `pr-summarizer` (no diagrams), `code-reviewer`, and content-triggered `silent-failure-hunter` / `pr-test-analyzer`. Reduces cost ~65% vs. full run.

### Findings structured data model
Phase 2 now collects findings as structured records `{severity, agent, file, line, finding, remediation}` before rendering markdown. This enables inline comment targeting while preserving the existing Block B terminal format.

## Related Issues & PRs

- Closes no existing issues (new feature)
- Related: #5 — Bitbucket/GitLab integration investigation (opened this session)
