### PR TITLE
Release v1.1.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "comprehensive-review",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "CodeRabbit-style PR review using parallel specialized agents. Produces structured PR summaries and severity-ranked findings from 10+ agents.",
   "author": {
     "name": "Tag1 Consulting",


### PR DESCRIPTION
## Summary

- Multi-provider support: GitHub (including Enterprise), GitLab, and Bitbucket — auto-detected from remote URL, with `--provider` override flag
- User confirmation gates before all write operations: PR/MR creation, summary comment posting, and inline review submission
- Persistent review history via optional [claude-mem](https://github.com/thedotmack/claude-mem) integration — patterns surfaced across reviews for architecture and security agents
- Provider-specific inline review behavior: GitHub uses COMMENT/REQUEST_CHANGES events; GitLab posts individual discussion threads; Bitbucket posts findings as a single PR comment

## What's changed since v1.0.1

- #16 — Add GitHub Enterprise, GitLab, and Bitbucket support
- #18 — Require user confirmation before GitHub write operations
- #17 — Add claude-mem integration for persistent review history
- #14 — Fix issue-linker local mode and non-GitHub repo handling

## Upgrade notes

- GitLab users need the [glab CLI](https://gitlab.com/gitlab-org/cli) installed
- Bitbucket users need a `BITBUCKET_TOKEN` or `BITBUCKET_APP_PASSWORD` env var set
- GitHub users: no changes required; `gh` CLI continues to be used as before
- claude-mem integration is opt-in via presence of a running claude-mem worker daemon; use `--no-mem` to disable

## Test plan

- [ ] GitHub: full review, `--create-pr`, `--post-summary`, `--pr <N>`
- [ ] GitLab: full review, `--create-pr`, inline comments via discussion threads
- [ ] Bitbucket: full review, findings posted as single PR comment
- [ ] Confirmation gates: verify prompt appears before each GitHub write
- [ ] `--local` / `--no-post`: verify no prompts and no writes
- [ ] claude-mem: verify prior review context appears in architecture/security agent output