### PR TITLE
Release v1.2.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "comprehensive-review",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "CodeRabbit-style PR review using parallel specialized agents. Produces structured PR summaries and severity-ranked findings from 10+ agents.",
   "author": {
     "name": "Tag1 Consulting",


### PR DESCRIPTION
## Summary

Releases version 1.2.0 of the comprehensive-review plugin by bumping the version field in the plugin manifest. This release packages the fix from issue #20, which adds explicit `subagent_type` values to the agent roster to prevent incorrect plugin-namespace inference by the Claude Code runtime.

**Type:** config
**Effort:** 1/5 — Single-field version bump in the plugin manifest.

## Walkthrough

| File | Change | Summary |
|------|--------|---------|
| `.claude-plugin/plugin.json` | Modified | Version bumped from `1.1.0` to `1.2.0` |

## What's in this release

### Bug fixes
- **#20** — Fix incorrect `pr-review-toolkit:pr-summarizer` subagent_type in `--pr` mode. Added explicit `subagent_type:` values to every agent entry in the Phase 1 Agent Roster in `SKILL.md`, eliminating the ambiguity that caused the orchestrator LLM to construct the wrong plugin-namespace prefix for our custom agents.

## Review findings

No findings — single-line version bump in plugin manifest.