### PR TITLE
docs: note Opus 4.7 as current harness model; fix code-reviewer label

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ The skill coordinates two groups of agents:
    - `issue-linker` — cross-references GitHub issues and PRs; returns NONE for non-GitHub providers (runs Haiku)
    - `security-reviewer` — OWASP-class security analysis (runs Opus)
    - `architecture-reviewer` — design pattern and coupling analysis (runs Opus)
+   - Both run on the `opus` alias, which the harness currently resolves to Opus 4.7 (`claude-opus-4-7`).
    - `blind-hunter` — context-free "fresh eyes" review; receives only the raw diff (small diffs), a plain file list (large diffs in normal mode), or the full diff from the worktree (large diffs in `--pr` mode) — no project context in any case (runs Sonnet). Adapted from BMAD-METHOD.
    - `edge-case-hunter` — mechanical boundary-condition path tracing (runs Sonnet). Adapted from BMAD-METHOD.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,8 @@ The skill coordinates two groups of agents:
    - `issue-linker` — cross-references GitHub issues and PRs; returns NONE for non-GitHub providers (runs Haiku)
    - `security-reviewer` — OWASP-class security analysis (runs Opus)
    - `architecture-reviewer` — design pattern and coupling analysis (runs Opus)
-   - Both run on the `opus` alias, which the harness currently resolves to Opus 4.7 (`claude-opus-4-7`).
+
+   Both Opus agents use the `opus` alias; the harness resolves this to the current Opus model (Opus 4.7 as of this writing).
    - `blind-hunter` — context-free "fresh eyes" review; receives only the raw diff (small diffs), a plain file list (large diffs in normal mode), or the full diff from the worktree (large diffs in `--pr` mode) — no project context in any case (runs Sonnet). Adapted from BMAD-METHOD.
    - `edge-case-hunter` — mechanical boundary-condition path tracing (runs Sonnet). Adapted from BMAD-METHOD.
 

--- a/README.md
+++ b/README.md
@@ -217,12 +217,14 @@ Run from any git repository, on the branch you want to review:
 
 ## Agent roster
 
+Opus agents (`architecture-reviewer`, `security-reviewer`) use the `opus` alias, which the Claude Code harness resolves to the current Opus model — currently Opus 4.7 (`claude-opus-4-7`).
+
 ### Full run
 
 | Agent | Model | Purpose | When it runs | Context |
 |-------|-------|---------|--------------|---------|
 | **pr-summarizer** | Sonnet | Summary, walkthrough table, Mermaid diagrams (opt-in), effort score | Always | Manifest + selective reads ² |
-| **code-reviewer** ¹ | Opus | Tactical bugs, style violations, project conventions | Always | Full diff |
+| **code-reviewer** ¹ | Sonnet | Tactical bugs, style violations, project conventions | Always | Full diff |
 | **architecture-reviewer** | Opus | System design, coupling, API design, technical debt | Full run only | Manifest + selective reads ² |
 | **security-reviewer** | Opus | OWASP-class security analysis, language-specific checks | Full run only | Manifest + selective reads ² |
 | **silent-failure-hunter** ¹ | — | Silent failures, inadequate error handling | If diff has error-handling patterns | Relevant file slices |

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Run from any git repository, on the branch you want to review:
 
 ## Agent roster
 
-Opus agents (`architecture-reviewer`, `security-reviewer`) use the `opus` alias, which the Claude Code harness resolves to the current Opus model — currently Opus 4.7 (`claude-opus-4-7`).
+Opus agents (`architecture-reviewer`, `security-reviewer`) use the `opus` alias, which the Claude Code harness resolves to the current Opus model.
 
 ### Full run
 


### PR DESCRIPTION
## Summary

Updates developer-facing documentation to record that the `opus` model alias resolves to Opus 4.7 in the Claude Code harness, and corrects a pre-existing label drift where `code-reviewer` was incorrectly listed as running on Opus in README.md (it runs on Sonnet, as assigned in SKILL.md).

**Type:** docs
**Effort:** 1/5 — Four-line documentation-only change with no logic, configuration, or behavioral impact.

## Walkthrough

| File | Change | Summary |
|------|--------|---------|
| `README.md` | Modified | Added harness resolution note for Opus agents above the roster table; corrected `code-reviewer` model label from Opus to Sonnet |
| `CLAUDE.md` | Modified | Added prose note (outside the agent bullet list) that the `opus` alias resolves to the current Opus model (Opus 4.7 as of this writing) |

## Notes

- No changes to `SKILL.md`, agent frontmatter, or `.claude-plugin/plugin.json` — this is documentation only.
- The `opus` alias is intentionally kept in code so the plugin tracks the frontier without requiring plugin releases on every model update.
- Review agents flagged (and this PR corrects): the initial draft placed the Opus note as a bullet-list item in CLAUDE.md (misleading formatting) and pinned `claude-opus-4-7` by ID in both files (maintenance debt). Both were fixed before this PR was created.