### PR TITLE
feat: add ai-pr-review GitHub Action via submodule

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -2,7 +2,7 @@ name: AI PR Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled]
 
 permissions:
   pull-requests: write
@@ -25,4 +25,4 @@ jobs:
           base-ref: ${{ github.base_ref }}
           head-sha: ${{ github.event.pull_request.head.sha }}
           pr-number: ${{ github.event.pull_request.number }}
-          review-mode: quick
+          review-mode: ${{ contains(github.event.pull_request.labels.*.name, 'ai-review-full') && 'full' || 'quick' }}

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -10,17 +10,27 @@ on:
 permissions:
   pull-requests: write
   contents: read
-  issues: write  # required for label removal in post-review step
+  issues: write
 
 concurrency:
   group: ai-pr-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
-  review:
+  # Job 1: validate config and check out the repo (including the private submodule)
+  # using the PAT. The PAT is only ever present in this job's git config; subsequent
+  # jobs receive the workspace via artifact and do not inherit git credentials.
+  prepare:
     runs-on: ubuntu-latest
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
+      # Only AI_REVIEW_API_KEY and AI_REVIEW_PROVIDER are validated here.
+      # AI_REVIEW_API_KEY: required — the composite action has no sensible default.
+      # AI_REVIEW_PROVIDER: validated defensively so the provider is explicit
+      #   rather than implicitly falling back to the action's 'anthropic' default.
+      # Other variables (AI_REVIEW_BASE_URL, AI_REVIEW_MODEL_STANDARD,
+      # AI_REVIEW_MODEL_PREMIUM) are intentionally optional — the composite action
+      # uses provider-appropriate defaults when they are empty.
       - name: Validate required configuration
         env:
           AI_REVIEW_API_KEY: ${{ secrets.AI_REVIEW_API_KEY }}
@@ -35,14 +45,42 @@ jobs:
             exit 1
           fi
 
-      # AI_PR_REVIEW_TOKEN requires: repo (to clone the private submodule)
+      # AI_PR_REVIEW_TOKEN requires: repo scope (to clone the private submodule).
       # If the submodule becomes public, GITHUB_TOKEN is sufficient instead.
+      # This token is scoped to this job only; the review job below does not
+      # use it and therefore does not have it in its git credential store.
       - name: Checkout with submodules
         uses: actions/checkout@v4
         with:
           submodules: true
           token: ${{ secrets.AI_PR_REVIEW_TOKEN }}
           fetch-depth: 0
+
+      - name: Upload workspace
+        uses: actions/upload-artifact@v4
+        with:
+          name: workspace
+          path: .
+          include-hidden-files: true
+          retention-days: 1
+
+  # Job 2: run the composite action against the checked-out workspace.
+  # This job re-downloads the workspace from the artifact — it does NOT run
+  # actions/checkout with the PAT, so the repo-scoped PAT is not present in
+  # this job's git config and is not accessible to the composite action or
+  # any subprocesses it spawns.
+  review:
+    needs: prepare
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download workspace
+        uses: actions/download-artifact@v4
+        with:
+          name: workspace
+          path: .
+
+      - name: Restore git executable bits
+        run: chmod +x .git/hooks/* 2>/dev/null || true
 
       - name: Run AI PR Review
         uses: ./.github/actions/ai-pr-review
@@ -59,8 +97,18 @@ jobs:
           review-mode: ${{ contains(github.event.pull_request.labels.*.name, 'ai-review-full') && 'full' || 'quick' }}
           force-full-diff: ${{ contains(github.event.pull_request.labels.*.name, 'ai-review-rescan') && 'true' || 'false' }}
 
+  # Job 3: remove the ai-review-rescan label after the review completes.
+  # Uses if: always() so this runs even when the review job is cancelled
+  # (e.g. by a concurrent synchronize event triggering the concurrency rule),
+  # preventing force-full-diff from persisting to subsequent pushes.
+  cleanup-rescan-label:
+    needs: review
+    if: always() && contains(github.event.pull_request.labels.*.name, 'ai-review-rescan')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
       - name: Remove ai-review-rescan label
-        if: contains(github.event.pull_request.labels.*.name, 'ai-review-rescan')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -20,7 +20,9 @@ jobs:
       - name: Run AI PR Review
         uses: ./.github/actions/ai-pr-review
         with:
-          api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          api-key: ${{ secrets.AI_REVIEW_API_KEY }}
+          provider: ${{ secrets.AI_REVIEW_PROVIDER }}
+          base-url: ${{ secrets.AI_REVIEW_BASE_URL }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ github.base_ref }}
           head-sha: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -10,7 +10,7 @@ on:
 permissions:
   pull-requests: write
   contents: read
-  issues: write
+  # issues: write is declared only on the cleanup-rescan-label job (least-privilege)
 
 concurrency:
   group: ai-pr-review-${{ github.event.pull_request.number }}
@@ -18,14 +18,14 @@ concurrency:
 
 jobs:
   # Job 1: validate config and check out the repo (including the private submodule)
-  # using the PAT. The PAT is only ever present in this job's git config; subsequent
-  # jobs receive the workspace via artifact and do not inherit git credentials.
+  # using the PAT. Credentials are scrubbed before uploading the workspace artifact
+  # so the PAT does not travel to the review job via the artifact's .git/config.
   prepare:
     runs-on: ubuntu-latest
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      # Only AI_REVIEW_API_KEY and AI_REVIEW_PROVIDER are validated here.
       # AI_REVIEW_API_KEY: required — the composite action has no sensible default.
+      # AI_PR_REVIEW_TOKEN: required — needed to clone the private submodule.
       # AI_REVIEW_PROVIDER: validated defensively so the provider is explicit
       #   rather than implicitly falling back to the action's 'anthropic' default.
       # Other variables (AI_REVIEW_BASE_URL, AI_REVIEW_MODEL_STANDARD,
@@ -34,10 +34,12 @@ jobs:
       - name: Validate required configuration
         env:
           AI_REVIEW_API_KEY: ${{ secrets.AI_REVIEW_API_KEY }}
+          AI_PR_REVIEW_TOKEN: ${{ secrets.AI_PR_REVIEW_TOKEN }}
           AI_REVIEW_PROVIDER: ${{ vars.AI_REVIEW_PROVIDER }}
         run: |
           missing=()
           [ -z "$AI_REVIEW_API_KEY" ] && missing+=("secret AI_REVIEW_API_KEY")
+          [ -z "$AI_PR_REVIEW_TOKEN" ] && missing+=("secret AI_PR_REVIEW_TOKEN")
           [ -z "$AI_REVIEW_PROVIDER" ] && missing+=("variable AI_REVIEW_PROVIDER")
           if [ ${#missing[@]} -gt 0 ]; then
             echo "ERROR: Missing required configuration: ${missing[*]}"
@@ -47,14 +49,17 @@ jobs:
 
       # AI_PR_REVIEW_TOKEN requires: repo scope (to clone the private submodule).
       # If the submodule becomes public, GITHUB_TOKEN is sufficient instead.
-      # This token is scoped to this job only; the review job below does not
-      # use it and therefore does not have it in its git credential store.
+      # This token is scoped to this job only; credentials are scrubbed before
+      # the workspace is uploaded so the PAT does not reach the review job.
       - name: Checkout with submodules
         uses: actions/checkout@v4
         with:
           submodules: true
           token: ${{ secrets.AI_PR_REVIEW_TOKEN }}
           fetch-depth: 0
+
+      - name: Scrub git credentials before artifact upload
+        run: git config --unset-all http.https://github.com/.extraheader || true
 
       - name: Upload workspace
         uses: actions/upload-artifact@v4
@@ -65,13 +70,13 @@ jobs:
           retention-days: 1
 
   # Job 2: run the composite action against the checked-out workspace.
-  # This job re-downloads the workspace from the artifact — it does NOT run
-  # actions/checkout with the PAT, so the repo-scoped PAT is not present in
-  # this job's git config and is not accessible to the composite action or
-  # any subprocesses it spawns.
+  # The workspace artifact has credentials scrubbed; this job does not run
+  # actions/checkout with the PAT so the repo-scoped PAT is never in this
+  # job's git config or accessible to the composite action.
   review:
     needs: prepare
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Download workspace
         uses: actions/download-artifact@v4
@@ -79,10 +84,12 @@ jobs:
           name: workspace
           path: .
 
+      # actions/upload-artifact strips file permissions. Restore execute bits
+      # on the composite action's shell scripts. Git hooks are NOT made
+      # executable — they are not needed for the review and enabling them
+      # would allow arbitrary code execution via a malicious hook in the PR.
       - name: Restore executable bits
-        run: |
-          chmod +x .git/hooks/* 2>/dev/null || true
-          find .github/actions/ai-pr-review -name "*.sh" -exec chmod +x {} +
+        run: find .github/actions/ai-pr-review -name "*.sh" -exec chmod +x {} +
 
       - name: Run AI PR Review
         uses: ./.github/actions/ai-pr-review
@@ -100,12 +107,14 @@ jobs:
           force-full-diff: ${{ contains(github.event.pull_request.labels.*.name, 'ai-review-rescan') && 'true' || 'false' }}
 
   # Job 3: remove the ai-review-rescan label after the review completes.
-  # Uses if: always() so this runs even when the review job is cancelled
-  # (e.g. by a concurrent synchronize event triggering the concurrency rule),
-  # preventing force-full-diff from persisting to subsequent pushes.
+  # needs: [prepare, review] with if: always() ensures this runs even when the
+  # review job is cancelled (e.g. by the concurrency rule on a new push).
+  # The fork guard is required because if: always() bypasses needs-skipping
+  # and this job would otherwise run for fork PRs that have the label.
+  # The gh api call ignores 404 in case the label was manually removed first.
   cleanup-rescan-label:
-    needs: review
-    if: always() && contains(github.event.pull_request.labels.*.name, 'ai-review-rescan')
+    needs: [prepare, review]
+    if: always() && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'ai-review-rescan')
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -116,4 +125,5 @@ jobs:
         run: |
           gh api \
             --method DELETE \
-            repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/ai-review-rescan
+            repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/ai-review-rescan \
+            || true

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -28,5 +28,7 @@ jobs:
           base-ref: ${{ github.base_ref }}
           head-sha: ${{ github.event.pull_request.head.sha }}
           pr-number: ${{ github.event.pull_request.number }}
+          model-standard: ${{ vars.AI_REVIEW_MODEL_STANDARD }}
+          model-premium: ${{ vars.AI_REVIEW_MODEL_PREMIUM }}
           review-mode: ${{ contains(github.event.pull_request.labels.*.name, 'ai-review-full') && 'full' || 'quick' }}
           force-full-diff: ${{ contains(github.event.pull_request.labels.*.name, 'ai-review-rescan') && 'true' || 'false' }}

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -1,0 +1,27 @@
+name: AI PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout with submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Run AI PR Review
+        uses: ./.github/actions/ai-pr-review
+        with:
+          api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          base-ref: ${{ github.base_ref }}
+          head-sha: ${{ github.event.pull_request.head.sha }}
+          pr-number: ${{ github.event.pull_request.number }}
+          review-mode: quick

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -106,15 +106,15 @@ jobs:
           review-mode: ${{ contains(github.event.pull_request.labels.*.name, 'ai-review-full') && 'full' || 'quick' }}
           force-full-diff: ${{ contains(github.event.pull_request.labels.*.name, 'ai-review-rescan') && 'true' || 'false' }}
 
-  # Job 3: remove the ai-review-rescan label after the review completes.
+  # Job 3: always attempt to remove the ai-review-rescan label.
+  # Running unconditionally (on non-fork PRs) avoids the "Skipped" indicator
+  # in the PR checks panel on normal pushes. The gh api call returns 404 when
+  # the label is absent; || true swallows it so the step always succeeds.
   # needs: [prepare, review] with if: always() ensures this runs even when the
   # review job is cancelled (e.g. by the concurrency rule on a new push).
-  # The fork guard is required because if: always() bypasses needs-skipping
-  # and this job would otherwise run for fork PRs that have the label.
-  # The gh api call ignores 404 in case the label was manually removed first.
   cleanup-rescan-label:
     needs: [prepare, review]
-    if: always() && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'ai-review-rescan')
+    if: always() && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -79,8 +79,10 @@ jobs:
           name: workspace
           path: .
 
-      - name: Restore git executable bits
-        run: chmod +x .git/hooks/* 2>/dev/null || true
+      - name: Restore executable bits
+        run: |
+          chmod +x .git/hooks/* 2>/dev/null || true
+          find .github/actions/ai-pr-review -name "*.sh" -exec chmod +x {} +
 
       - name: Run AI PR Review
         uses: ./.github/actions/ai-pr-review

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -28,3 +28,4 @@ jobs:
           head-sha: ${{ github.event.pull_request.head.sha }}
           pr-number: ${{ github.event.pull_request.number }}
           review-mode: ${{ contains(github.event.pull_request.labels.*.name, 'ai-review-full') && 'full' || 'quick' }}
+          force-full-diff: ${{ contains(github.event.pull_request.labels.*.name, 'ai-review-rescan') && 'true' || 'false' }}

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -21,8 +21,8 @@ jobs:
         uses: ./.github/actions/ai-pr-review
         with:
           api-key: ${{ secrets.AI_REVIEW_API_KEY }}
-          provider: ${{ secrets.AI_REVIEW_PROVIDER }}
-          base-url: ${{ secrets.AI_REVIEW_BASE_URL }}
+          provider: ${{ vars.AI_REVIEW_PROVIDER }}
+          base-url: ${{ vars.AI_REVIEW_BASE_URL }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ github.base_ref }}
           head-sha: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+          token: ${{ secrets.AI_PR_REVIEW_TOKEN }}
 
       - name: Run AI PR Review
         uses: ./.github/actions/ai-pr-review

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -4,13 +4,39 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
 
+# Only run on PRs from this repo — forks cannot access secrets anyway, and this
+# prevents untrusted fork branches from triggering jobs with write permissions.
+# See: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections
 permissions:
   pull-requests: write
+  contents: read
+  issues: write  # required for label removal in post-review step
+
+concurrency:
+  group: ai-pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   review:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
+      - name: Validate required configuration
+        env:
+          AI_REVIEW_API_KEY: ${{ secrets.AI_REVIEW_API_KEY }}
+          AI_REVIEW_PROVIDER: ${{ vars.AI_REVIEW_PROVIDER }}
+        run: |
+          missing=()
+          [ -z "$AI_REVIEW_API_KEY" ] && missing+=("secret AI_REVIEW_API_KEY")
+          [ -z "$AI_REVIEW_PROVIDER" ] && missing+=("variable AI_REVIEW_PROVIDER")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "ERROR: Missing required configuration: ${missing[*]}"
+            echo "See the README for setup instructions."
+            exit 1
+          fi
+
+      # AI_PR_REVIEW_TOKEN requires: repo (to clone the private submodule)
+      # If the submodule becomes public, GITHUB_TOKEN is sufficient instead.
       - name: Checkout with submodules
         uses: actions/checkout@v4
         with:
@@ -32,3 +58,12 @@ jobs:
           model-premium: ${{ vars.AI_REVIEW_MODEL_PREMIUM }}
           review-mode: ${{ contains(github.event.pull_request.labels.*.name, 'ai-review-full') && 'full' || 'quick' }}
           force-full-diff: ${{ contains(github.event.pull_request.labels.*.name, 'ai-review-rescan') && 'true' || 'false' }}
+
+      - name: Remove ai-review-rescan label
+        if: contains(github.event.pull_request.labels.*.name, 'ai-review-rescan')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            --method DELETE \
+            repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/ai-review-rescan

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           submodules: true
           token: ${{ secrets.AI_PR_REVIEW_TOKEN }}
+          fetch-depth: 0
 
       - name: Run AI PR Review
         uses: ./.github/actions/ai-pr-review

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".github/actions/ai-pr-review"]
+	path = .github/actions/ai-pr-review
+	url = git@github.com:tag1consulting/ai-pr-review.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule ".github/actions/ai-pr-review"]
 	path = .github/actions/ai-pr-review
-	url = git@github.com:tag1consulting/ai-pr-review.git
+	url = https://github.com/tag1consulting/ai-pr-review.git


### PR DESCRIPTION
## Summary

- Embeds [`tag1consulting/ai-pr-review`](https://github.com/tag1consulting/ai-pr-review) as a git submodule at `.github/actions/ai-pr-review`
- Adds `.github/workflows/ai-pr-review.yml` that triggers on every PR open/sync/reopen event
- Runs in `quick` mode, posting findings as inline review comments on the PR

## Setup required

Add `ANTHROPIC_API_KEY` as a repository secret in **Settings → Secrets and variables → Actions** before merging.

## Test plan

- [x] Confirm `ANTHROPIC_API_KEY` secret is set in repo settings
- [ ] Open a test PR and verify the `AI PR Review` workflow triggers and posts review comments
- [ ] Confirm submodule initializes correctly in the Actions runner (`actions/checkout@v4` with `submodules: true`)