### PR TITLE
docs: add subagent_type to CLAUDE.md guidance, jq to README requirements, fix code-reviewer model drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ The orchestrator uses a tiered approach to minimize token consumption:
 - **Small diffs (under 300 lines)**: Full diff passed inline to all agents — at this size, the tool-call overhead of selective reads exceeds the token cost of including the full diff.
 - **Medium/large diffs (300+ lines)**: Custom agents receive a structured **file manifest** (file list, categories, languages, line counts) and use selective `git diff <base>...HEAD -- <file>` reads. Toolkit agents (which we cannot modify) receive only the diff slices relevant to their specialty. Lockfiles, vendor directories, and checksum files are excluded from the manifest (but remain in DIFF_FILE).
 
-The orchestrator also pre-reads CLAUDE.md and the commit log in Phase 0, passing condensed versions to agents so they don't fetch these independently. The orchestrator always specifies `model:` explicitly when spawning agents via the Agent tool — subagents otherwise inherit the orchestrator's (Opus) model rather than using the model in their frontmatter.
+The orchestrator also pre-reads CLAUDE.md and the commit log in Phase 0, passing condensed versions to agents so they don't fetch these independently. The orchestrator always specifies both `model:` and `subagent_type:` explicitly when spawning agents via the Agent tool — `model:` prevents subagents from inheriting the orchestrator's model, and `subagent_type:` prevents incorrect plugin-namespace inference.
 
 ### Agent scope boundaries
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ In short: pr-review-toolkit agents handle tactical code review. This skill orche
 | [gh CLI](https://cli.github.com/) | Required for GitHub / GitHub Enterprise |
 | [glab CLI](https://gitlab.com/gitlab-org/cli) | Required for GitLab |
 | `BITBUCKET_TOKEN` env var | Required for Bitbucket (`BITBUCKET_APP_PASSWORD` is auto-mapped if set) |
+| `jq` | Required for GitLab and Bitbucket (JSON parsing) |
 | `pr-review-toolkit@claude-plugins-official` | Required plugin — provides code-reviewer, silent-failure-hunter, pr-test-analyzer, comment-analyzer, type-design-analyzer |
 
 ## Provider support
@@ -222,7 +223,7 @@ Run from any git repository, on the branch you want to review:
 | Agent | Model | Purpose | When it runs | Context |
 |-------|-------|---------|--------------|---------|
 | **pr-summarizer** | Sonnet | Summary, walkthrough table, Mermaid diagrams (opt-in), effort score | Always | Manifest + selective reads ² |
-| **code-reviewer** ¹ | Opus | Tactical bugs, style violations, project conventions | Always | Full diff |
+| **code-reviewer** ¹ | Sonnet | Tactical bugs, style violations, project conventions | Always | Full diff |
 | **architecture-reviewer** | Opus | System design, coupling, API design, technical debt | Full run only | Manifest + selective reads ² |
 | **security-reviewer** | Opus | OWASP-class security analysis, language-specific checks | Full run only | Manifest + selective reads ² |
 | **silent-failure-hunter** ¹ | — | Silent failures, inadequate error handling | If diff has error-handling patterns | Relevant file slices |


### PR DESCRIPTION
## Summary

- **Closes #34** — `CLAUDE.md` editing guidance now documents that the orchestrator must specify both `model:` and `subagent_type:` explicitly when spawning agents. The existing guidance only mentioned `model:`, leaving out the equally-important `subagent_type:` fix from PR #21.
- **Closes #30 (README half)** — `jq` added to the Requirements table, scoped to GitLab and Bitbucket. The SKILL.md half (validation step in Provider Detection) is handled separately in the GitLab/jq PR.
- **README drift fix** — `code-reviewer` row corrected from `Opus` to `Sonnet` to match `SKILL.md` lines 255/270, which have always spawned it on Sonnet. Issue #24 proposed an experiment to potentially flip this to Opus; that issue is being closed as won't-do, so Sonnet remains correct.

## Test plan

- [ ] Read `CLAUDE.md` line 44 — sentence now covers both `model:` and `subagent_type:`
- [ ] Read `README.md` Requirements table — `jq` row present between `BITBUCKET_TOKEN` and `pr-review-toolkit` rows
- [ ] Read `README.md` agent roster table — `code-reviewer` row shows `Sonnet`, matching `SKILL.md` lines 255 and 270