### PR TITLE
fix: lockfile pathspec, blind-hunter mktemp, claude-mem health check timeout

### DIFF
--- a/skills/comprehensive-review/SKILL.md
+++ b/skills/comprehensive-review/SKILL.md
@@ -146,7 +146,7 @@ The following operations are referenced by name throughout Phases 0, 4, and 4b. 
 1b. **Detect claude-mem availability** (skip if `--no-mem` was passed):
    - Read the worker port: `MEM_PORT=$(jq -r '.CLAUDE_MEM_WORKER_PORT // "37777"' ~/.claude-mem/settings.json 2>/dev/null || echo "37777")`
    - Validate port: `[[ "$MEM_PORT" =~ ^[0-9]+$ ]] && (( MEM_PORT >= 1 && MEM_PORT <= 65535 )) || MEM_PORT=37777`
-   - Health check: `curl -sf "http://127.0.0.1:${MEM_PORT}/api/health" >/dev/null 2>&1`
+   - Health check: `curl -sf --max-time 2 "http://127.0.0.1:${MEM_PORT}/api/health" >/dev/null 2>&1`
    - If the curl succeeds: set MEM_AVAILABLE=true. If it fails or `--no-mem` was passed: set MEM_AVAILABLE=false. No error message either way.
 
 **Help text:** Read and display `skills/comprehensive-review/HELP.md`, then stop. If the file is not found, display: "Help file not found. Run `/plugins install comprehensive-review@tag1consulting` to reinstall."
@@ -166,7 +166,7 @@ The following operations are referenced by name throughout Phases 0, 4, and 4b. 
 
 3. Run `git diff --name-only <base>...HEAD` to confirm changed files (in `--pr` mode: `git -C "$WORKTREE_PATH" diff --name-only <base>...HEAD`). If none, report and stop.
 
-4. **Build the file manifest** from `git diff --stat <base>...HEAD -- ':!*lock.json' ':!*lock.yaml' ':!vendor/*' ':!*.sum' ':!node_modules/*'`:
+4. **Build the file manifest** from `git diff --stat <base>...HEAD -- ':!*lock.json' ':!*lock.yaml' ':!*.lock' ':!*.sum' ':!vendor/*' ':!node_modules/*'`:
    Lockfiles, vendor directories, and checksum files are excluded — the full DIFF_FILE still includes them.
    - Detect languages from extensions; categorize files as **Source**, **Tests**, **Config**, **Docs**, or **Dependency**
    - Format:
@@ -278,7 +278,7 @@ Produce slices via `mktemp /tmp/cr-slice-<agent>-XXXXXXXX.txt` and `git diff <ba
 - **blind-hunter** (subagent_type: `blind-hunter`, model: sonnet) — **ZERO CONTEXT CONSTRAINT: pass ONLY the diff. No manifest, no project context, no commit log.**
   Small diffs: full diff inline only.
   Medium/large (non-`--pr`): base branch name + plain file list from `git diff --name-only` (NOT the categorized manifest). Agent reads files via `git diff <base>...HEAD -- <file>`.
-  Medium/large (`--pr` mode): `git -C "$WORKTREE_PATH" diff <base>...HEAD > /tmp/cr-diff-blind.txt`, passes inline (agent has no worktree knowledge).
+  Medium/large (`--pr` mode): `BLIND_DIFF_FILE=$(mktemp /tmp/cr-diff-blind-XXXXXXXX.txt) && git -C "$WORKTREE_PATH" diff <base>...HEAD > "$BLIND_DIFF_FILE"`, passes `$BLIND_DIFF_FILE` inline (agent has no worktree knowledge). Track for Phase 5 cleanup.
 - **edge-case-hunter** (subagent_type: `edge-case-hunter`, model: sonnet) — pass manifest, commit log, project context. Small diffs: also full diff inline.
   Has full codebase read access for surrounding context.
 


### PR DESCRIPTION
## Summary

- **Closes #33** — Added `':!*.lock'` to the `git diff --stat` pathspec in Phase 0 step 4. This catches `yarn.lock`, `Cargo.lock`, `Gemfile.lock`, `composer.lock`, `poetry.lock`, `Pipfile.lock`, and any other `*.lock` file that the previous patterns missed. Without this, a PR that regenerates a large lockfile alongside a small source change could be misclassified as Medium/Large, causing agents to receive a manifest instead of the inline diff.

- **Closes #32** — Replaced the hardcoded `/tmp/cr-diff-blind.txt` path in the Phase 1 blind-hunter `--pr` mode instruction with `mktemp /tmp/cr-diff-blind-XXXXXXXX.txt`. Matches the existing convention in SKILL.md (see Phase 0 line 160, Phase 1 line 223). Without this, two concurrent `--pr` invocations would silently overwrite each other's blind-hunter input.

- **Closes #27 (part 1)** — Added `--max-time 2` to the `curl` health check for the claude-mem worker in Phase 0 step 1b. Without a timeout, a hung (alive but unresponsive) worker could block the skill for ~2 minutes. The integration is designed to fail silently; a 2-minute hang is not silent.

## Test plan

- [ ] Grep SKILL.md for `':!*.lock'` — present on Phase 0 step 4 line
- [ ] Grep SKILL.md for `/tmp/cr-diff-blind.txt` — zero matches (hardcoded path removed)
- [ ] Grep SKILL.md for `cr-diff-blind-XXXXXXXX` — present in blind-hunter `--pr` mode instruction
- [ ] Grep SKILL.md for `--max-time 2` — present in step 1b curl command