### PR TITLE
fix(#31): restore remote-URL fallback in issue-linker when PROVIDER is absent

### DIFF
--- a/agents/issue-linker.md
+++ b/agents/issue-linker.md
@@ -23,7 +23,9 @@ Note: The orchestrator skips this agent for `--quick`, `--pr`, and `--no-post`/`
 This step guards against non-GitHub providers and runtime GitHub access failures.
 
 Before doing any work:
-1. If the PROVIDER value in your task description is NOT `github`, or if no PROVIDER value is present, output exactly `NONE` and stop. Issue cross-referencing is only supported for GitHub repositories.
+1. If the PROVIDER value in your task description is explicitly set to a non-`github` value, output exactly `NONE` and stop.
+   If PROVIDER is absent or empty, fall back: run `git remote get-url origin 2>/dev/null` — if the URL does not contain `github.com`, output exactly `NONE` and stop.
+   Issue cross-referencing is only supported for GitHub repositories.
 2. Run `gh auth status 2>/dev/null` — if not authenticated (exit code non-zero), output exactly `NONE` and stop.
 
 ## Step 1: Parse Explicit Issue References


### PR DESCRIPTION
## Summary

- **Closes #31** — `agents/issue-linker.md` Step 0 now distinguishes three cases:
  1. **PROVIDER explicitly set to non-`github`** → output `NONE` and stop (unchanged behavior)
  2. **PROVIDER absent or empty** → fall back to `git remote get-url origin 2>/dev/null` and check for `github.com` in the URL (restored behavior from before PR #16)
  3. **PROVIDER=github** → proceed normally (unchanged behavior)

Before this fix, a missing PROVIDER was treated the same as an explicit non-GitHub provider — causing the agent to silently return `NONE` when invoked directly (debugging, testing, ad-hoc use) even on a valid GitHub repo. The skill always passes PROVIDER, so the orchestrator fast-path is unaffected.

## Test plan

- [ ] Read `agents/issue-linker.md` Step 0 — three-branch logic present
- [ ] Confirm explicit non-github PROVIDER still stops immediately
- [ ] Confirm absent PROVIDER falls back to remote URL check