### PR TITLE
feat: add deterministic CVE check via OSV.dev (Phase 1b)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "comprehensive-review",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "CodeRabbit-style PR review using parallel specialized agents. Produces structured PR summaries and severity-ranked findings from 10+ agents.",
   "author": {
     "name": "Tag1 Consulting",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ This copies files from the local working tree into `~/.claude/` without fetching
 
 The skill and agents are entirely Claude Code markdown files. Understanding how they fit together:
 
-### Two-tier agent model
+### Analysis components
 
 The skill coordinates two groups of agents:
 
@@ -37,7 +37,7 @@ The skill coordinates two groups of agents:
    - These are not in this repo and must not be duplicated here
 
 3. **Deterministic checks** (non-agent, in `scripts/`):
-   - `run-cve-check.sh` — queries OSV.dev for known CVEs in changed dependency manifests (`go.mod`, `package.json`, `requirements.txt`, `composer.json`). Runs in Phase 1b (after agents are launched, before Phase 2 normalization). Emits `{ severity, agent, file, line, finding, remediation }` tuples (same shape as agent findings) with `agent: "dependency-check"`. Runs in both full and `--quick` mode when manifest files are present.
+   - `run-cve-check.sh` — queries OSV.dev for known vulnerabilities in changed dependency manifests (`go.mod`, `package.json`, `requirements.txt`, `composer.json`). Runs in Phase 1b (after agents are launched, before Phase 2 normalization). Emits `{ severity, agent, file, line, finding, remediation }` tuples (same shape as agent findings) with `agent: "dependency-check"`. Runs in both full and `--quick` mode when manifest files are present.
 
 ### Token-efficient context passing
 
@@ -89,7 +89,7 @@ Each agent uses its own severity scale. The skill's `SKILL.md` defines a normali
 
 ### Agent tiers
 
-Agents are divided into three tiers:
+Agents are divided into four tiers:
 
 1. **Always-run:** pr-summarizer, code-reviewer — run in every mode including `--quick`
 2. **Full-run only (skip with `--quick`):** architecture-reviewer, security-reviewer, blind-hunter, edge-case-hunter, comment-analyzer, type-design-analyzer, issue-linker (also skipped with `--pr`, `--no-post`/`--local`, and on non-GitHub repos)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,9 @@ The skill coordinates two groups of agents:
    - `code-reviewer`, `silent-failure-hunter`, `pr-test-analyzer`, `comment-analyzer`, `type-design-analyzer`
    - These are not in this repo and must not be duplicated here
 
+3. **Deterministic checks** (non-agent, in `scripts/`):
+   - `run-cve-check.sh` — queries OSV.dev for known CVEs in changed dependency manifests (`go.mod`, `package.json`, `requirements.txt`, `composer.json`). Runs in Phase 1b (after agents are launched, before Phase 2 normalization). Emits `{ severity, agent, file, line, finding, remediation }` tuples (same shape as agent findings) with `agent: "dependency-check"`. Runs in both full and `--quick` mode when manifest files are present.
+
 ### Token-efficient context passing
 
 The orchestrator uses a tiered approach to minimize token consumption:
@@ -91,6 +94,7 @@ Agents are divided into three tiers:
 1. **Always-run:** pr-summarizer, code-reviewer — run in every mode including `--quick`
 2. **Full-run only (skip with `--quick`):** architecture-reviewer, security-reviewer, blind-hunter, edge-case-hunter, comment-analyzer, type-design-analyzer, issue-linker (also skipped with `--pr`, `--no-post`/`--local`, and on non-GitHub repos)
 3. **Conditional (run in both full and `--quick` when triggered by diff content):** silent-failure-hunter (error patterns), pr-test-analyzer (test files)
+4. **Deterministic (non-agent, conditional on manifest files):** `dependency-check` via `scripts/run-cve-check.sh` — runs in both full and `--quick` when `go.mod`, `package.json`, `requirements.txt`, or `composer.json` appear in the diff
 
 The `--quick` flag eliminates the two expensive Opus review agents, the two BMAD-inspired Sonnet agents (blind-hunter, edge-case-hunter), and the lower-value conditional agents, reducing cost by ~75% while preserving the core code review and error/test analysis.
 
@@ -160,6 +164,7 @@ agents/security-reviewer.md            ← security analysis
 agents/architecture-reviewer.md        ← architectural analysis
 agents/blind-hunter.md                 ← context-free "fresh eyes" review (adapted from BMAD-METHOD)
 agents/edge-case-hunter.md             ← boundary-condition path tracing (adapted from BMAD-METHOD)
+scripts/run-cve-check.sh               ← deterministic CVE check via OSV.dev (Phase 1b)
 install.sh                             ← legacy file-copy installer (recommends plugin install)
 ```
 
@@ -174,3 +179,4 @@ install.sh                             ← legacy file-copy installer (recommend
 - **blind-hunter** has a unique context constraint: it must receive ONLY the diff or plain file list — no manifest, no project context, no commit log. If you change the context-passing strategy in `SKILL.md`, verify blind-hunter's constraint is still enforced. The agent file itself also instructs the agent to ignore any extra context it receives.
 - When modifying provider-specific behavior, update the Provider Operations Reference block, all three provider branches (github/gitlab/bitbucket) within Phases 0, 4, and 4b, and the provider support matrix in README.md.
 - **BMAD attribution**: `blind-hunter` and `edge-case-hunter` were adapted from BMAD-METHOD (MIT License, BMad Code LLC). Attribution is present in both agent files and in README.md. Do not remove attribution when editing these agents.
+- **`scripts/run-cve-check.sh`** implements the CVE check invoked in Phase 1b. CVSS parsing, OSV schema handling, and severity mapping all live in this script. If the OSV API response shape or CVSS vector format changes, update this file. The `OSV_MOCK_FILE` env var is for offline testing only; never set it in production.

--- a/README.md
+++ b/README.md
@@ -395,5 +395,5 @@ rm ~/.claude/agents/security-reviewer.md
 rm ~/.claude/agents/architecture-reviewer.md
 rm ~/.claude/agents/blind-hunter.md
 rm ~/.claude/agents/edge-case-hunter.md
-rm -rf ~/.claude/scripts/run-cve-check.sh
+rm -f ~/.claude/scripts/run-cve-check.sh
 ```

--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ cp agents/security-reviewer.md ~/.claude/agents/
 cp agents/architecture-reviewer.md ~/.claude/agents/
 cp agents/blind-hunter.md ~/.claude/agents/
 cp agents/edge-case-hunter.md ~/.claude/agents/
+
+# Scripts
+mkdir -p ~/.claude/scripts
+cp scripts/run-cve-check.sh ~/.claude/scripts/
+chmod +x ~/.claude/scripts/run-cve-check.sh
 ```
 
 Then install the dependency plugin inside Claude Code:
@@ -236,10 +241,20 @@ Opus agents (`architecture-reviewer`, `security-reviewer`) use the `opus` alias,
 | **edge-case-hunter** | Sonnet | Mechanical path tracing: missing else/default, unguarded inputs, off-by-one, overflow, race conditions, resource leaks | Full run only | Manifest + selective reads ² |
 | **issue-linker** | Haiku | Finds referenced issues and related PRs/issues (GitHub only) | Full run only; skipped in `--pr`, `--local`/`--no-post`, and non-GitHub repos | Commit log + branch + manifest |
 
+### Deterministic checks
+
+In addition to LLM agents, the skill runs a deterministic CVE check when dependency manifests are in the diff:
+
+| Check | Trigger | Runs in `--quick`? |
+|-------|---------|-------------------|
+| **dependency-check** — queries [OSV.dev](https://osv.dev/) for known vulnerabilities in declared dependency versions | `go.mod`, `package.json`, `requirements.txt`, or `composer.json` changed | Yes |
+
+No API key required. Network failures are non-blocking (returns empty, warns to stderr). Findings appear in Block B as `[dependency-check]` entries.
+
 ### `--quick` mode
 
 Skips: architecture-reviewer, security-reviewer, blind-hunter, edge-case-hunter, comment-analyzer, type-design-analyzer, issue-linker.
-Still runs: pr-summarizer (no diagrams), code-reviewer, and triggered silent-failure-hunter / pr-test-analyzer.
+Still runs: pr-summarizer (no diagrams), code-reviewer, triggered silent-failure-hunter / pr-test-analyzer, and the CVE check if manifest files changed.
 
 ¹ From the `pr-review-toolkit@claude-plugins-official` plugin.
 ² For small diffs (under 300 lines), the full diff is passed inline instead.
@@ -380,4 +395,5 @@ rm ~/.claude/agents/security-reviewer.md
 rm ~/.claude/agents/architecture-reviewer.md
 rm ~/.claude/agents/blind-hunter.md
 rm ~/.claude/agents/edge-case-hunter.md
+rm -rf ~/.claude/scripts/run-cve-check.sh
 ```

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -68,7 +68,7 @@ on unchanged lines.
 - New dependencies: check if from trusted sources
 - Unpinned dependency versions that could pull malicious updates
 - Use of `latest` image tags in container definitions
-- New transitive dependencies with known CVEs (flag for manual `govulncheck`/`npm audit`)
+- Known CVEs in direct dependencies are detected deterministically by the `dependency-check` step (Phase 1b); do not re-flag those. Report dependency-related security concerns beyond CVE matches: maintainer changes, typosquat suspicion, overly broad permissions, or new license concerns.
 
 ## Language-Specific Checks
 

--- a/install.sh
+++ b/install.sh
@@ -200,6 +200,21 @@ for agent in pr-summarizer issue-linker security-reviewer architecture-reviewer 
 done
 
 # ---------------------------------------------------------------------------
+# Install scripts
+# ---------------------------------------------------------------------------
+
+mkdir -p "$CLAUDE_DIR/scripts"
+for script in run-cve-check.sh; do
+  dest="$CLAUDE_DIR/scripts/${script}"
+  if [[ -f "$dest" ]]; then
+    warn "Script already exists, overwriting: $dest"
+  fi
+  install_file "scripts/${script}" "$dest"
+  chmod +x "$dest"
+  info "Installed script → $dest"
+done
+
+# ---------------------------------------------------------------------------
 # Install pr-review-toolkit plugin
 # ---------------------------------------------------------------------------
 

--- a/install.sh
+++ b/install.sh
@@ -204,6 +204,7 @@ done
 # ---------------------------------------------------------------------------
 
 mkdir -p "$CLAUDE_DIR/scripts"
+# shellcheck disable=SC2043  # single item now; loop for future scripts
 for script in run-cve-check.sh; do
   dest="$CLAUDE_DIR/scripts/${script}"
   if [[ -f "$dest" ]]; then

--- a/scripts/run-cve-check.sh
+++ b/scripts/run-cve-check.sh
@@ -1,0 +1,353 @@
+#!/usr/bin/env bash
+#
+# run-cve-check.sh — Query OSV.dev for known vulnerabilities in dependency
+# manifests touched by the PR and emit findings in the comprehensive-review
+# structured tuple format.
+#
+# Usage:
+#   ./run-cve-check.sh <changed_files_newline_separated>
+#
+#   Or via stdin:
+#   git diff --name-only base...HEAD | ./run-cve-check.sh
+#
+# Output:
+#   JSON array of { severity, agent, file, line, finding, remediation } tuples.
+#   Outputs "[]" if no manifests changed, no vulnerabilities found, or the
+#   OSV API is unavailable.
+#
+# Environment:
+#   OSV_MOCK_FILE   When set to a readable file path, read the OSV response
+#                   from that file instead of calling the network. Used for
+#                   offline testing; must be unset in production.
+#   OSV_API_URL     Override OSV endpoint (default: https://api.osv.dev/v1/query).
+#
+# Supported manifests:
+#   go.mod, package.json, requirements.txt, composer.json
+#
+# Adapted from tag1consulting/ai-pr-review (MIT License).
+
+set -euo pipefail
+
+# Accept changed files as positional arg or stdin
+if [[ -n "${1:-}" ]]; then
+  CHANGED_FILES="$1"
+else
+  CHANGED_FILES=$(cat)
+fi
+OSV_API_URL="${OSV_API_URL:-https://api.osv.dev/v1/query}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "WARNING: jq not installed; CVE check skipped." >&2
+  echo "[]"
+  exit 0
+fi
+
+# --- Collect relevant manifest files from the changed list ---------------
+MANIFEST_FILES=()
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+  case "$(basename "$file")" in
+    go.mod|package.json|requirements.txt|composer.json)
+      [[ -f "$file" ]] && MANIFEST_FILES+=("$file")
+      ;;
+  esac
+done <<<"$CHANGED_FILES"
+
+if [[ ${#MANIFEST_FILES[@]} -eq 0 ]]; then
+  echo "[]"
+  exit 0
+fi
+
+# --- Helpers -------------------------------------------------------------
+
+# Query OSV.dev for a single package@version. Prints the raw JSON response
+# on stdout, or an empty string on any failure (so callers can short-circuit).
+query_osv() {
+  local ecosystem="$1" name="$2" version="$3"
+
+  if [[ -n "${OSV_MOCK_FILE:-}" ]]; then
+    if [[ -r "$OSV_MOCK_FILE" ]]; then
+      cat "$OSV_MOCK_FILE" 2>/dev/null || echo ""
+      return 0
+    fi
+    echo "WARNING: OSV_MOCK_FILE set but not readable: ${OSV_MOCK_FILE}" >&2
+    echo ""
+    return 0
+  fi
+
+  local body
+  body=$(jq -n \
+    --arg eco "$ecosystem" \
+    --arg pkg "$name" \
+    --arg ver "$version" \
+    '{version: $ver, package: {name: $pkg, ecosystem: $eco}}')
+
+  curl -sS --max-time 10 --retry 2 --retry-delay 1 \
+    -H 'Content-Type: application/json' \
+    -X POST "$OSV_API_URL" \
+    -d "$body" 2>/dev/null || echo ""
+}
+
+# Find the 1-based line number in $file where the package declaration appears.
+# Uses manifest-aware anchored patterns so comments/unrelated strings don't match.
+# Falls back to 1 if no match is found. Line numbers are best-effort — a
+# suppression should target the finding text, not the line.
+line_for_package() {
+  local file="$1" needle="$2"
+  local base line pattern escaped
+  base=$(basename "$file")
+  # shellcheck disable=SC2016  # sed script is intentionally a literal BRE
+  escaped=$(printf '%s' "$needle" | sed 's/[][\.*^$()+?{}|/]/\\&/g')
+  case "$base" in
+    package.json|composer.json)
+      pattern="\"${escaped}\"[[:space:]]*:"
+      line=$(grep -n -E -m 1 -- "$pattern" "$file" 2>/dev/null | cut -d: -f1)
+      ;;
+    go.mod)
+      pattern="[[:space:]]${escaped}[[:space:]]"
+      line=$(grep -n -E -m 1 -- "$pattern" "$file" 2>/dev/null | cut -d: -f1)
+      ;;
+    requirements.txt)
+      pattern="^[[:space:]]*${escaped}[[:space:]]*(==|\\[|\$)"
+      line=$(grep -n -E -m 1 -- "$pattern" "$file" 2>/dev/null | cut -d: -f1)
+      ;;
+    *)
+      line=$(grep -n -F -m 1 -- "$needle" "$file" 2>/dev/null | cut -d: -f1)
+      ;;
+  esac
+  echo "${line:-1}"
+}
+
+# Convert an OSV response JSON to zero or more findings for a given
+# (file, package, version). Each vuln becomes one finding object.
+osv_to_findings() {
+  local file="$1" pkg="$2" version="$3" ecosystem="$4" response="$5"
+
+  if [[ -z "$response" ]]; then
+    echo "[]"
+    return 0
+  fi
+  if ! echo "$response" | jq -e 'type == "object" and (.vulns // [] | length) > 0' >/dev/null 2>&1; then
+    echo "[]"
+    return 0
+  fi
+
+  local line
+  line=$(line_for_package "$file" "$pkg")
+
+  echo "$response" | jq -c \
+      --arg file "$file" --arg pkg "$pkg" --arg ver "$version" \
+      --arg eco "$ecosystem" --argjson line "$line" '
+    # Roundup to one decimal per CVSS v3.1 spec.
+    def roundup_cvss: (. * 10) | ceil / 10;
+
+    # Parse a CVSS v3.x vector string into a base score using the
+    # standard CVSS v3.1 formula. Returns null if the vector cannot
+    # be parsed (unknown CVSS version, missing required metric).
+    def cvss_v3_score($vec):
+      ( $vec
+        | split("/")
+        | map(select(test("^[A-Z]+:[A-Z]+$")))
+        | map(split(":") | {(.[0]): .[1]})
+        | add // {} ) as $m
+      | if ($m["AV"] and $m["AC"] and $m["PR"] and $m["UI"]
+             and $m["S"] and $m["C"] and $m["I"] and $m["A"]) | not
+        then null
+        else
+          ( {N:0.85, A:0.62, L:0.55, P:0.20}[$m["AV"]] ) as $av
+        | ( {L:0.77, H:0.44}[$m["AC"]] ) as $ac
+        | ( if $m["S"] == "C"
+              then {N:0.85, L:0.68, H:0.50}[$m["PR"]]
+              else {N:0.85, L:0.62, H:0.27}[$m["PR"]] end ) as $pr
+        | ( {N:0.85, R:0.62}[$m["UI"]] ) as $ui
+        | ( {H:0.56, L:0.22, N:0.0}[$m["C"]] ) as $c
+        | ( {H:0.56, L:0.22, N:0.0}[$m["I"]] ) as $i
+        | ( {H:0.56, L:0.22, N:0.0}[$m["A"]] ) as $a
+        | if ($av == null or $ac == null or $pr == null
+              or $ui == null or $c == null or $i == null or $a == null)
+          then null
+          else
+            (1 - ((1 - $c) * (1 - $i) * (1 - $a))) as $iss
+          | ( if $m["S"] == "C"
+                then 7.52 * ($iss - 0.029) - 3.25 * (pow($iss - 0.02; 15))
+                else 6.42 * $iss end ) as $impact
+          | (8.22 * $av * $ac * $pr * $ui) as $exploit
+          | if $impact <= 0
+              then 0
+              else
+                ( if $m["S"] == "C"
+                    then [1.08 * ($impact + $exploit), 10] | min
+                    else [$impact + $exploit, 10] | min end
+                ) | roundup_cvss
+              end
+          end
+        end;
+
+    # Extract a numeric score from an OSV severity entry.
+    # Real OSV responses put the CVSS vector alone in .score; legacy/test
+    # fixtures may include a trailing "(9.8)" or a bare number. Try each.
+    def parse_score($s):
+      ( if ($s | type) != "string" then null
+        elif ($s | test("^CVSS:3"; "i")) then cvss_v3_score($s)
+        elif ($s | test("\\([0-9]+(\\.[0-9]+)?\\)"))
+          then ($s | capture("\\((?<n>[0-9]+(\\.[0-9]+)?)\\)").n | tonumber)
+        elif ($s | test("^[0-9]+(\\.[0-9]+)?$"))
+          then ($s | tonumber)
+        else null end );
+
+    def pick_cvss:
+      ( [.severity[]? | select(.type | test("CVSS"; "i")) | .score]
+        | map(parse_score(.)) | map(select(. != null))
+        | if length > 0 then max else null end );
+
+    # Severity mapping. When CVSS cannot be parsed we fail safe to Medium,
+    # not Low, so a novel score format does not silently downgrade a real
+    # Critical CVE below the reviewer-noticeable tier.
+    def severity_label($cvss):
+      if $cvss == null then "Medium"
+      elif $cvss >= 9.0 then "Critical"
+      elif $cvss >= 7.0 then "High"
+      elif $cvss >= 4.0 then "Medium"
+      else "Low" end;
+
+    # Pick the first fixed version from affected entries that match the
+    # queried package name + ecosystem. Falls back to scanning all affected
+    # entries only if no name+ecosystem match exists (defensive; real OSV
+    # responses always match).
+    def fixed_version:
+      . as $vuln
+      | ( [ $vuln.affected[]?
+            | select(.package.name == $pkg and (.package.ecosystem // "") == $eco)
+            | .ranges[]?.events[]? | select(.fixed) | .fixed ] | first ) as $matched
+      | ( [ $vuln.affected[]?.ranges[]?.events[]? | select(.fixed) | .fixed ] | first ) as $any
+      | $matched // $any // "unknown";
+
+    def cve_id:
+      ( [.aliases[]? | select(startswith("CVE-"))] | first // .id );
+
+    [ .vulns[]? as $v | $v |
+      (pick_cvss) as $score |
+      {
+        severity: severity_label($score),
+        agent: "dependency-check",
+        file: $file,
+        line: $line,
+        finding: ("\(cve_id) (\($v.id)): \($v.summary // $v.details // "Known vulnerability"). Affects \($pkg)@\($ver)."),
+        remediation: ("Upgrade \($pkg) to \(fixed_version) or later. See https://osv.dev/vulnerability/\($v.id)")
+      }
+    ]
+  '
+}
+
+# --- Manifest parsers ----------------------------------------------------
+# Each parser prints "<ecosystem>\t<name>\t<version>" lines to stdout.
+
+parse_go_mod() {
+  local file="$1"
+  awk '
+    /^require[[:space:]]+\(/ { in_block=1; next }
+    in_block && /^\)/ { in_block=0; next }
+    {
+      line=$0
+      sub(/\/\/.*$/, "", line)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+      if (line == "") next
+      if (in_block) {
+        n = split(line, f, /[[:space:]]+/)
+        if (n >= 2 && f[2] ~ /^v/) printf "Go\t%s\t%s\n", f[1], substr(f[2], 2)
+      } else if ($1 == "require") {
+        n = split(line, f, /[[:space:]]+/)
+        if (n >= 3 && f[3] ~ /^v/) printf "Go\t%s\t%s\n", f[2], substr(f[3], 2)
+      }
+    }
+  ' "$file"
+}
+
+parse_package_json() {
+  local file="$1"
+  jq -r '
+    (.dependencies // {}) + (.devDependencies // {})
+    | to_entries[]
+    | select(.value | type == "string")
+    | select(.value | test("^[0-9]"; ""))
+    | "npm\t\(.key)\t\(.value | ltrimstr("^") | ltrimstr("~") | ltrimstr(">=") | ltrimstr(">") | ltrimstr("="))"
+  ' "$file" 2>/dev/null || true
+}
+
+parse_requirements_txt() {
+  local file="$1"
+  grep -E '^[[:space:]]*[A-Za-z0-9_.-]' "$file" 2>/dev/null \
+    | grep -v '^[[:space:]]*#' \
+    | sed 's/[[:space:]]*#.*//' \
+    | grep '==' \
+    | while IFS= read -r line; do
+        # Strip leading whitespace
+        line="${line#"${line%%[! ]*}"}"
+        pkg=$(echo "$line" | cut -d= -f1 | tr -d ' ')
+        ver=$(echo "$line" | sed 's/.*==//' | sed 's/[[:space:]].*//')
+        [[ -n "$pkg" && -n "$ver" ]] && printf "PyPI\t%s\t%s\n" "$pkg" "$ver"
+      done
+}
+
+parse_composer_json() {
+  local file="$1"
+  jq -r '
+    (.require // {}) + (.["require-dev"] // {})
+    | to_entries[]
+    | select(.key | startswith("ext-") | not)
+    | select(.key | startswith("php") | not)
+    | select(.value | type == "string")
+    | select(.value | test("^[0-9]"; ""))
+    | "Packagist\t\(.key)\t\(.value | ltrimstr("^") | ltrimstr("~") | ltrimstr(">=") | ltrimstr(">") | ltrimstr("="))"
+  ' "$file" 2>/dev/null || true
+}
+
+# Skip non-numeric or wildcard version strings that OSV cannot resolve.
+is_queryable_version() {
+  local ver="$1"
+  [[ -z "$ver" ]] && return 1
+  [[ "$ver" == "*" || "$ver" == "latest" || "$ver" == "x" ]] && return 1
+  [[ "$ver" =~ ^[0-9] ]] || return 1
+  # Skip git URLs and local paths
+  [[ "$ver" =~ ^(git\+|github:|file:) ]] && return 1
+  return 0
+}
+
+# --- Main loop -----------------------------------------------------------
+
+FINDINGS="[]"
+CHECKED=0
+
+for manifest in "${MANIFEST_FILES[@]}"; do
+  base=$(basename "$manifest")
+
+  case "$base" in
+    go.mod)          packages=$(parse_go_mod "$manifest") ;;
+    package.json)    packages=$(parse_package_json "$manifest") ;;
+    requirements.txt) packages=$(parse_requirements_txt "$manifest") ;;
+    composer.json)   packages=$(parse_composer_json "$manifest") ;;
+    *)               continue ;;
+  esac
+
+  [[ -z "$packages" ]] && continue
+
+  while IFS=$'\t' read -r ecosystem name version; do
+    [[ -z "$ecosystem" || -z "$name" || -z "$version" ]] && continue
+    is_queryable_version "$version" || continue
+
+    response=$(query_osv "$ecosystem" "$name" "$version")
+    [[ -z "$response" ]] && continue
+
+    vuln_findings=$(osv_to_findings "$manifest" "$name" "$version" "$ecosystem" "$response")
+    if [[ "$vuln_findings" != "[]" && -n "$vuln_findings" ]]; then
+      FINDINGS=$(jq -n --argjson a "$FINDINGS" --argjson b "$vuln_findings" '$a + $b')
+    fi
+    (( CHECKED++ )) || true
+  done <<<"$packages"
+done
+
+if [[ "$CHECKED" -gt 0 ]]; then
+  echo "CVE check: queried ${CHECKED} package versions" >&2
+fi
+
+printf '%s\n' "$FINDINGS"

--- a/scripts/run-cve-check.sh
+++ b/scripts/run-cve-check.sh
@@ -35,6 +35,7 @@ else
   CHANGED_FILES=$(cat)
 fi
 OSV_API_URL="${OSV_API_URL:-https://api.osv.dev/v1/query}"
+_OSV_MOCK_WARNED=0
 
 if ! command -v jq >/dev/null 2>&1; then
   echo "WARNING: jq not installed; CVE check skipped." >&2
@@ -66,9 +67,12 @@ query_osv() {
   local ecosystem="$1" name="$2" version="$3"
 
   if [[ -n "${OSV_MOCK_FILE:-}" ]]; then
-    echo "WARNING: OSV_MOCK_FILE is set — using mock data, not live OSV API. Unset in production." >&2
+    if [[ "$_OSV_MOCK_WARNED" -eq 0 ]]; then
+      echo "WARNING: OSV_MOCK_FILE is set — using mock data, not live OSV API. Unset in production." >&2
+      _OSV_MOCK_WARNED=1
+    fi
     if [[ -r "$OSV_MOCK_FILE" ]]; then
-      cat "$OSV_MOCK_FILE" 2>/dev/null || echo ""
+      cat "$OSV_MOCK_FILE" || echo ""
       return 0
     fi
     echo "WARNING: OSV_MOCK_FILE set but not readable: ${OSV_MOCK_FILE}" >&2
@@ -83,13 +87,19 @@ query_osv() {
     --arg ver "$version" \
     '{version: $ver, package: {name: $pkg, ecosystem: $eco}}')
 
-  osv_response=$(curl -sS --max-time 10 --retry 2 --retry-delay 1 \
+  osv_response=$(curl -sS --fail-with-body --max-time 10 --max-filesize 2097152 \
+    --retry 2 --retry-delay 1 --retry-all-errors \
     -H 'Content-Type: application/json' \
     -X POST "$OSV_API_URL" \
     -d "$body" 2>/dev/null)
   curl_exit=$?
   if [[ $curl_exit -ne 0 ]]; then
     echo "WARNING: OSV API request failed (curl exit ${curl_exit}) for ${ecosystem}/${name}@${version}" >&2
+    echo ""
+    return 0
+  fi
+  if ! echo "$osv_response" | jq -e 'type == "object"' >/dev/null 2>&1; then
+    echo "WARNING: OSV API returned non-JSON for ${ecosystem}/${name}@${version}" >&2
     echo ""
     return 0
   fi
@@ -129,9 +139,14 @@ line_for_package() {
 # Convert an OSV response JSON to zero or more findings for a given
 # (file, package, version). Each vuln becomes one finding object.
 osv_to_findings() {
-  local file="$1" pkg="$2" version="$3" ecosystem="$4" response="$5"
+  local file="$1" pkg="$2" version="$3" ecosystem="$4" response="$5" deptag="${6:-}"
 
   if [[ -z "$response" ]]; then
+    echo "[]"
+    return 0
+  fi
+  if ! echo "$response" | jq -e '.' >/dev/null 2>&1; then
+    echo "WARNING: OSV returned non-JSON for ${pkg}@${version}" >&2
     echo "[]"
     return 0
   fi
@@ -145,7 +160,7 @@ osv_to_findings() {
 
   echo "$response" | jq -c \
       --arg file "$file" --arg pkg "$pkg" --arg ver "$version" \
-      --arg eco "$ecosystem" --argjson line "$line" '
+      --arg eco "$ecosystem" --argjson line "$line" --arg deptag "$deptag" '
     # Roundup to one decimal per CVSS v3.1 spec.
     def roundup_cvss: (. * 10) | ceil / 10;
 
@@ -240,7 +255,7 @@ osv_to_findings() {
         agent: "dependency-check",
         file: $file,
         line: $line,
-        finding: ("\(cve_id) (\($v.id)): \($v.summary // $v.details // "Known vulnerability"). Affects \($pkg)@\($ver)."),
+        finding: ("\(cve_id) (\($v.id)): \($v.summary // $v.details // "Known vulnerability"). Affects \($pkg)@\($ver)\(if $deptag == "dev" then " (dev dependency)" else "" end)."),
         remediation: ("Upgrade \($pkg) to \(fixed_version) or later. See https://osv.dev/vulnerability/\($v.id)")
       }
     ]
@@ -251,8 +266,8 @@ osv_to_findings() {
 # Each parser prints "<ecosystem>\t<name>\t<version>" lines to stdout.
 
 parse_go_mod() {
-  local file="$1"
-  awk '
+  local file="$1" result
+  if ! result=$(awk '
     /^require[[:space:]]+\(/ { in_block=1; next }
     in_block && /^\)/ { in_block=0; next }
     {
@@ -268,18 +283,23 @@ parse_go_mod() {
         if (n >= 3 && f[3] ~ /^v/) printf "Go\t%s\t%s\n", f[2], substr(f[3], 2)
       }
     }
-  ' "$file"
+  ' "$file" 2>&1); then
+    echo "WARNING: Failed to parse ${file}: ${result}" >&2
+    return 0
+  fi
+  echo "$result"
 }
 
 parse_package_json() {
   local file="$1" result
   if ! result=$(jq -r '
-    (.dependencies // {}) + (.devDependencies // {})
-    | to_entries[]
+    [(.dependencies // {}) | to_entries[] | .tag = "prod"] +
+    [(.devDependencies // {}) | to_entries[] | .tag = "dev"]
+    | .[]
     | select(.value | type == "string")
-    | (.value | ltrimstr("^") | ltrimstr("~") | ltrimstr(">=") | ltrimstr(">") | ltrimstr("=")) as $ver
+    | (.value | gsub("^[\\^~>=v]+"; "")) as $ver
     | select($ver | test("^[0-9]"; ""))
-    | "npm\t\(.key)\t\($ver)"
+    | "npm\t\(.key)\t\($ver)\t\(.tag)"
   ' "$file" 2>&1); then
     echo "WARNING: Failed to parse ${file}: ${result}" >&2
     return 0
@@ -292,7 +312,7 @@ parse_requirements_txt() {
   grep -E '^[[:space:]]*[A-Za-z0-9_.-]' "$file" 2>/dev/null \
     | grep -v '^[[:space:]]*#' \
     | sed 's/[[:space:]]*#.*//' \
-    | grep '==' \
+    | { grep '==' || true; } \
     | while IFS= read -r line; do
         # Strip leading whitespace
         line="${line#"${line%%[! ]*}"}"
@@ -310,8 +330,9 @@ parse_composer_json() {
     | to_entries[]
     | select(.key | startswith("ext-") | not)
     | select(.key | startswith("php") | not)
+    | select(.key | startswith("lib-") | not)
     | select(.value | type == "string")
-    | (.value | ltrimstr("^") | ltrimstr("~") | ltrimstr(">=") | ltrimstr(">") | ltrimstr("=")) as $ver
+    | (.value | gsub("^[\\^~>=v]+"; "")) as $ver
     | select($ver | test("^[0-9]"; ""))
     | "Packagist\t\(.key)\t\($ver)"
   ' "$file" 2>&1); then
@@ -321,14 +342,13 @@ parse_composer_json() {
   echo "$result"
 }
 
-# Skip non-numeric or wildcard version strings that OSV cannot resolve.
+# Skip version strings OSV cannot resolve: wildcards, non-numeric prefixes
+# (git+, github:, file:, etc. are all rejected by the digit-start check below).
 is_queryable_version() {
   local ver="$1"
   [[ -z "$ver" ]] && return 1
   [[ "$ver" == "*" || "$ver" == "latest" || "$ver" == "x" ]] && return 1
   [[ "$ver" =~ ^[0-9] ]] || return 1
-  # Skip git URLs and local paths
-  [[ "$ver" =~ ^(git\+|github:|file:) ]] && return 1
   return 0
 }
 
@@ -351,7 +371,7 @@ for manifest in "${MANIFEST_FILES[@]}"; do
 
   [[ -z "$packages" ]] && continue
 
-  while IFS=$'\t' read -r ecosystem name version; do
+  while IFS=$'\t' read -r ecosystem name version deptag; do
     [[ -z "$ecosystem" || -z "$name" || -z "$version" ]] && continue
     is_queryable_version "$version" || continue
 
@@ -359,10 +379,15 @@ for manifest in "${MANIFEST_FILES[@]}"; do
 
     response=$(query_osv "$ecosystem" "$name" "$version")
     [[ -z "$response" ]] && continue
+    CHECKED=$(( CHECKED + 1 ))
 
     local_findings=""
-    if ! local_findings=$(osv_to_findings "$manifest" "$name" "$version" "$ecosystem" "$response"); then
-      echo "WARNING: Failed to parse OSV findings for ${ecosystem}/${name}@${version}" >&2
+    if ! local_findings=$(osv_to_findings "$manifest" "$name" "$version" "$ecosystem" "$response" "${deptag:-}" 2>&1); then
+      echo "WARNING: Failed to parse OSV findings for ${ecosystem}/${name}@${version}: ${local_findings}" >&2
+      continue
+    fi
+    if ! echo "$local_findings" | jq -e 'type == "array"' >/dev/null 2>&1; then
+      echo "WARNING: Unexpected osv_to_findings output for ${ecosystem}/${name}@${version}" >&2
       continue
     fi
 
@@ -374,11 +399,11 @@ for manifest in "${MANIFEST_FILES[@]}"; do
         FINDINGS="$merged"
       fi
     fi
-    CHECKED=$(( CHECKED + 1 ))
   done <<<"$packages"
 done
 
 if [[ "$ATTEMPTED" -gt 0 ]]; then
+  # ATTEMPTED = packages with queryable versions; CHECKED = packages that received an OSV response
   echo "CVE check: queried ${CHECKED}/${ATTEMPTED} package versions" >&2
 fi
 

--- a/scripts/run-cve-check.sh
+++ b/scripts/run-cve-check.sh
@@ -66,6 +66,7 @@ query_osv() {
   local ecosystem="$1" name="$2" version="$3"
 
   if [[ -n "${OSV_MOCK_FILE:-}" ]]; then
+    echo "WARNING: OSV_MOCK_FILE is set — using mock data, not live OSV API. Unset in production." >&2
     if [[ -r "$OSV_MOCK_FILE" ]]; then
       cat "$OSV_MOCK_FILE" 2>/dev/null || echo ""
       return 0
@@ -75,17 +76,24 @@ query_osv() {
     return 0
   fi
 
-  local body
+  local body osv_response curl_exit
   body=$(jq -n \
     --arg eco "$ecosystem" \
     --arg pkg "$name" \
     --arg ver "$version" \
     '{version: $ver, package: {name: $pkg, ecosystem: $eco}}')
 
-  curl -sS --max-time 10 --retry 2 --retry-delay 1 \
+  osv_response=$(curl -sS --max-time 10 --retry 2 --retry-delay 1 \
     -H 'Content-Type: application/json' \
     -X POST "$OSV_API_URL" \
-    -d "$body" 2>/dev/null || echo ""
+    -d "$body" 2>/dev/null)
+  curl_exit=$?
+  if [[ $curl_exit -ne 0 ]]; then
+    echo "WARNING: OSV API request failed (curl exit ${curl_exit}) for ${ecosystem}/${name}@${version}" >&2
+    echo ""
+    return 0
+  fi
+  echo "$osv_response"
 }
 
 # Find the 1-based line number in $file where the package declaration appears.
@@ -264,14 +272,19 @@ parse_go_mod() {
 }
 
 parse_package_json() {
-  local file="$1"
-  jq -r '
+  local file="$1" result
+  if ! result=$(jq -r '
     (.dependencies // {}) + (.devDependencies // {})
     | to_entries[]
     | select(.value | type == "string")
-    | select(.value | test("^[0-9]"; ""))
-    | "npm\t\(.key)\t\(.value | ltrimstr("^") | ltrimstr("~") | ltrimstr(">=") | ltrimstr(">") | ltrimstr("="))"
-  ' "$file" 2>/dev/null || true
+    | (.value | ltrimstr("^") | ltrimstr("~") | ltrimstr(">=") | ltrimstr(">") | ltrimstr("=")) as $ver
+    | select($ver | test("^[0-9]"; ""))
+    | "npm\t\(.key)\t\($ver)"
+  ' "$file" 2>&1); then
+    echo "WARNING: Failed to parse ${file}: ${result}" >&2
+    return 0
+  fi
+  echo "$result"
 }
 
 parse_requirements_txt() {
@@ -283,23 +296,29 @@ parse_requirements_txt() {
     | while IFS= read -r line; do
         # Strip leading whitespace
         line="${line#"${line%%[! ]*}"}"
-        pkg=$(echo "$line" | cut -d= -f1 | tr -d ' ')
+        # Strip extras (e.g. requests[security] -> requests)
+        pkg=$(echo "$line" | cut -d= -f1 | sed 's/\[.*\]//' | tr -d ' ')
         ver=$(echo "$line" | sed 's/.*==//' | sed 's/[[:space:]].*//')
         [[ -n "$pkg" && -n "$ver" ]] && printf "PyPI\t%s\t%s\n" "$pkg" "$ver"
       done
 }
 
 parse_composer_json() {
-  local file="$1"
-  jq -r '
+  local file="$1" result
+  if ! result=$(jq -r '
     (.require // {}) + (.["require-dev"] // {})
     | to_entries[]
     | select(.key | startswith("ext-") | not)
     | select(.key | startswith("php") | not)
     | select(.value | type == "string")
-    | select(.value | test("^[0-9]"; ""))
-    | "Packagist\t\(.key)\t\(.value | ltrimstr("^") | ltrimstr("~") | ltrimstr(">=") | ltrimstr(">") | ltrimstr("="))"
-  ' "$file" 2>/dev/null || true
+    | (.value | ltrimstr("^") | ltrimstr("~") | ltrimstr(">=") | ltrimstr(">") | ltrimstr("=")) as $ver
+    | select($ver | test("^[0-9]"; ""))
+    | "Packagist\t\(.key)\t\($ver)"
+  ' "$file" 2>&1); then
+    echo "WARNING: Failed to parse ${file}: ${result}" >&2
+    return 0
+  fi
+  echo "$result"
 }
 
 # Skip non-numeric or wildcard version strings that OSV cannot resolve.
@@ -317,6 +336,7 @@ is_queryable_version() {
 
 FINDINGS="[]"
 CHECKED=0
+ATTEMPTED=0
 
 for manifest in "${MANIFEST_FILES[@]}"; do
   base=$(basename "$manifest")
@@ -335,19 +355,31 @@ for manifest in "${MANIFEST_FILES[@]}"; do
     [[ -z "$ecosystem" || -z "$name" || -z "$version" ]] && continue
     is_queryable_version "$version" || continue
 
+    ATTEMPTED=$(( ATTEMPTED + 1 ))
+
     response=$(query_osv "$ecosystem" "$name" "$version")
     [[ -z "$response" ]] && continue
 
-    vuln_findings=$(osv_to_findings "$manifest" "$name" "$version" "$ecosystem" "$response")
-    if [[ "$vuln_findings" != "[]" && -n "$vuln_findings" ]]; then
-      FINDINGS=$(jq -n --argjson a "$FINDINGS" --argjson b "$vuln_findings" '$a + $b')
+    local_findings=""
+    if ! local_findings=$(osv_to_findings "$manifest" "$name" "$version" "$ecosystem" "$response"); then
+      echo "WARNING: Failed to parse OSV findings for ${ecosystem}/${name}@${version}" >&2
+      continue
     fi
-    (( CHECKED++ )) || true
+
+    if [[ "$local_findings" != "[]" && -n "$local_findings" ]]; then
+      merged=""
+      if ! merged=$(jq -n --argjson a "$FINDINGS" --argjson b "$local_findings" '$a + $b' 2>&1); then
+        echo "WARNING: Failed to merge findings for ${ecosystem}/${name}@${version}: ${merged}" >&2
+      else
+        FINDINGS="$merged"
+      fi
+    fi
+    CHECKED=$(( CHECKED + 1 ))
   done <<<"$packages"
 done
 
-if [[ "$CHECKED" -gt 0 ]]; then
-  echo "CVE check: queried ${CHECKED} package versions" >&2
+if [[ "$ATTEMPTED" -gt 0 ]]; then
+  echo "CVE check: queried ${CHECKED}/${ATTEMPTED} package versions" >&2
 fi
 
 printf '%s\n' "$FINDINGS"

--- a/skills/comprehensive-review/HELP.md
+++ b/skills/comprehensive-review/HELP.md
@@ -44,6 +44,11 @@ Agents — --quick mode
   Conditional:       silent-failure-hunter, pr-test-analyzer (if patterns match)
   Skipped:           all full-run-only + comment-analyzer, type-design-analyzer, issue-linker
 
+Deterministic checks (both full and --quick)
+  dependency-check:  Queries OSV.dev for CVEs in changed dependency manifests.
+                     Triggers on: go.mod, package.json, requirements.txt, composer.json.
+                     No API key required. Network failures are non-blocking.
+
 claude-mem Integration (optional)
   When claude-mem is detected, the skill automatically stores a structured review
   summary to persistent memory and passes up to 5 prior review summaries as context

--- a/skills/comprehensive-review/SKILL.md
+++ b/skills/comprehensive-review/SKILL.md
@@ -170,6 +170,7 @@ The following operations are referenced by name throughout Phases 0, 4, and 4b. 
 4. **Build the file manifest** from `git diff --stat <base>...HEAD -- ':!*lock.json' ':!*lock.yaml' ':!*.lock' ':!*.sum' ':!vendor/*' ':!node_modules/*'`:
    Lockfiles, vendor directories, and checksum files are excluded — the full DIFF_FILE still includes them.
    - Detect languages from extensions; categorize files as **Source**, **Tests**, **Config**, **Docs**, or **Dependency**
+   - Also collect `MANIFEST_FILES` — the subset of changed files named `go.mod`, `package.json`, `requirements.txt`, or `composer.json`. Use `git diff --name-only <base>...HEAD` (no exclusions) and filter by basename. Store as a newline-separated list for Phase 1b.
    - Format:
      ```
      BASE: <base>  |  LANGUAGES: Go, TypeScript  |  FILES: <N>  |  LINES: +<added>/-<removed>
@@ -242,8 +243,8 @@ Produce slices via `mktemp /tmp/cr-slice-<agent>-XXXXXXXX.txt` and `git diff <ba
 
 | Flag | Agents that run |
 |------|-----------------|
-| (none) | All always-run + all triggered conditional agents (no diagrams unless `--diagrams` passed) |
-| `--quick` | pr-summarizer (no diagrams) + code-reviewer + triggered silent-failure-hunter and pr-test-analyzer |
+| (none) | All always-run + all triggered conditional agents (no diagrams unless `--diagrams` passed) + CVE check if manifest files changed |
+| `--quick` | pr-summarizer (no diagrams) + code-reviewer + triggered silent-failure-hunter and pr-test-analyzer + CVE check if manifest files changed |
 | `--no-post` / `--local` | Same as default but skips issue-linker; all Phase 4 GitHub operations suppressed |
 | `--security-only` | security-reviewer only |
 | `--summary-only` | pr-summarizer only |
@@ -263,6 +264,7 @@ Produce slices via `mktemp /tmp/cr-slice-<agent>-XXXXXXXX.txt` and `git diff <ba
 | comment-analyzer | `pr-review-toolkit:comment-analyzer` | sonnet |
 | type-design-analyzer | `pr-review-toolkit:type-design-analyzer` | sonnet |
 | issue-linker | `issue-linker` | haiku |
+| dependency-check | `scripts/run-cve-check.sh` (script, not agent) | n/a |
 
 **Always-run agents** (unless `--security-only` or `--summary-only` limits scope):
 
@@ -301,6 +303,33 @@ grep -l -E 'catch\b|if err|try \{|rescue\b|Result<|unwrap|\.error\(|\.expect\(|r
 
 Track skipped agents and reasons for Phase 5. Launch all applicable agents simultaneously.
 
+### Phase 1b: Deterministic Checks
+
+Run after all Phase 1 agents are launched (they run in parallel; this runs in the foreground while awaiting agent results).
+
+**CVE / dependency vulnerability check** — run when `MANIFEST_FILES` is non-empty (skip if `--summary-only` or `--security-only` mode; run in all other modes including `--quick`):
+
+```bash
+CVE_SCRIPT="${CLAUDE_DIR:-$HOME/.claude}/scripts/run-cve-check.sh"
+CVE_JSON="[]"
+if [[ -x "$CVE_SCRIPT" ]]; then
+  CVE_JSON=$(bash "$CVE_SCRIPT" <<<"$MANIFEST_FILES") || {
+    echo "WARNING: run-cve-check.sh failed; CVE findings will be skipped." >&2
+    CVE_JSON="[]"
+  }
+else
+  echo "WARNING: scripts/run-cve-check.sh not found; CVE check skipped. Re-run install to add it." >&2
+fi
+```
+
+`CLAUDE_DIR` defaults to `$HOME/.claude` (the standard Claude Code config directory). The script reads the manifest file list from stdin, queries OSV.dev for each declared dependency, and emits a JSON array of `{ severity, agent, file, line, finding, remediation }` tuples — the same structure as Phase 2 agent findings — with `agent: "dependency-check"`.
+
+- Capture `CVE_JSON` from stdout; on any non-zero exit, set to `[]` and emit a warning to stderr.
+- Network failures are non-blocking: the script returns `[]` and logs to stderr.
+- `--no-post`/`--local` does **not** skip the CVE check; it only gates posting.
+
+After all Phase 1 agents complete and Phase 1b finishes, proceed to Phase 2.
+
 ### Phase 2: Collect and Normalize Results
 
 Wait for all agents. Check each output:
@@ -320,8 +349,11 @@ Wait for all agents. Check each output:
 | type-design-analyzer | rating [1,2] / [3,5] / [6,10] | High / Medium / Low |
 | architecture-reviewer, security-reviewer | Critical/High/Medium | pass through (Medium+ only) |
 | blind-hunter, edge-case-hunter | Critical/High/Medium/Low | pass through |
+| dependency-check | Critical/High/Medium/Low | pass through (identity mapping) |
 
-**Deduplicate:** same `file:line` from two agents → keep highest severity, note "(also flagged by [agent2])". Same file without line → deduplicate by file + category.
+Also merge CVE findings from Phase 1b: if `CVE_JSON` is non-empty, add its entries to the normalized findings list before deduplication.
+
+**Deduplicate:** same `file:line` from two agents → keep highest severity, note "(also flagged by [agent2])". When a `dependency-check` finding and an LLM agent finding share the same `file:line`, prefer the `dependency-check` entry (it carries the authoritative CVE/GHSA ID) and append "(also flagged by [agent])". Same file without line → deduplicate by file + category.
 
 **Collect as structured data:** `{ severity, agent, file, line, finding, remediation }` per finding. Used for Block B rendering and Phase 4b inline comments.
 


### PR DESCRIPTION
## Summary

- Adds `scripts/run-cve-check.sh` — a deterministic dependency vulnerability checker that queries [OSV.dev](https://osv.dev/) for known CVEs in changed manifest files (`go.mod`, `package.json`, `requirements.txt`, `composer.json`) and emits findings in the same `{ severity, agent, file, line, finding, remediation }` tuple format as LLM agents, with `agent: "dependency-check"`
- Integrates as a new **Phase 1b** step in SKILL.md — runs after Phase 1 agents are launched, before Phase 2 normalization; active in both full and `--quick` modes when manifest files are in the diff
- Updates `security-reviewer` to cross-reference Phase 1b instead of suggesting manual `govulncheck`/`npm audit`
- Bumps version to `1.3.0`

Adapted from [tag1consulting/ai-pr-review#64](https://github.com/tag1consulting/ai-pr-review/pull/64) (commits `03f036f` + `fca9acc`), with the output schema updated for comprehensive-review's tuple shape and the invocation mechanism adapted from shell-out to in-skill `Bash` tool call.

## Walkthrough

| File | Change | Summary |
|------|--------|---------|
| `scripts/run-cve-check.sh` | Added | New deterministic CVE check script: parses four manifest formats, queries OSV.dev, computes CVSS v3.1 scores in `jq`, and emits structured findings tuples |
| `skills/comprehensive-review/SKILL.md` | Modified | Adds Phase 1b definition, `MANIFEST_FILES` collection in Phase 0, CVE findings merge and deduplication rules in Phase 2, `dependency-check` entry in the agent roster table, and updated mode flag descriptions |
| `install.sh` | Modified | Adds a `scripts/` installation loop that copies and `chmod +x`s `run-cve-check.sh` to `~/.claude/scripts/` |
| `README.md` | Modified | Documents the new "Deterministic checks" section, updates the `--quick` mode description, and adds `run-cve-check.sh` to the manual install and uninstall command blocks |
| `CLAUDE.md` | Modified | Adds a third tier to the two-tier agent model (deterministic checks), adds `dependency-check` to the agent tiers list, adds `scripts/run-cve-check.sh` to the file layout, and adds an editing guideline for the script |
| `agents/security-reviewer.md` | Modified | Narrows the security reviewer's dependency scope — removes CVE re-flagging instruction; redirects to non-CVE dependency concerns |
| `skills/comprehensive-review/HELP.md` | Modified | Adds a "Deterministic checks" block to the `--help` output |
| `.claude-plugin/plugin.json` | Modified | Bumps version from `1.2.0` to `1.3.0` |

## Test plan

- [x] `bash -n scripts/run-cve-check.sh` and `shellcheck` pass clean
- [x] Live OSV test: `gin v1.6.0` returns CVEs with correct severity and remediation
- [x] Live OSV test: `express ^4.18.2` and `lodash 4.17.11` both detected (critical fix verified)
- [x] Network failure path (`OSV_API_URL=http://127.0.0.1:1`) returns `[]` with exit 0
- [x] `/comprehensive-review --quick --local` run on this branch found no issues (no manifests in the diff, so Phase 1b correctly skips)
- [ ] Manual: run on a branch with a vulnerable `go.mod` or `package.json` and confirm `[dependency-check]` findings appear in Block B

## Review findings addressed

Both code-reviewer and silent-failure-hunter ran during pre-PR review. All findings were fixed in commit `344cab2` before this PR was opened:

- **Critical:** `parse_package_json`/`parse_composer_json` digit filter ran before `^`/`~` prefix strip — virtually all npm/Composer deps silently skipped
- **High (×5):** curl failures silent; jq parse errors swallowed; osv_to_findings failures dropped; FINDINGS accumulation unhandled; OSV_MOCK_FILE used without warning
- **Medium (×3):** requirements.txt extras not stripped; ATTEMPTED/CHECKED conflated; README `rm -rf` → `rm -f`