### PR TITLE
feat: v1.4.0 — Opus 4.7, batch CVE check, --depth flag, token efficiency

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "comprehensive-review",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "CodeRabbit-style PR review using parallel specialized agents. Produces structured PR summaries and severity-ranked findings from 10+ agents.",
   "author": {
     "name": "Tag1 Consulting",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ The key invariant: Block A is posted only when `--create-pr` is passed and no PR
 
 ### Severity normalization
 
-Each agent uses its own severity scale. The skill's `SKILL.md` defines a normalization table (Phase 2) that maps agent-specific scales to a unified Critical/High/Medium/Low scale, and deduplicates findings when two agents flag the same `file:line`. CVE findings with no CVSS score available use a synthetic `Unknown` tier, which normalizes conservatively to High.
+Each agent uses its own severity scale. The skill's `SKILL.md` defines a normalization table (Phase 2) that maps agent-specific scales to a unified Critical/High/Medium/Low scale, and deduplicates findings when two agents flag the same `file:line`. CVE findings whose CVSS vector cannot be parsed (CVSS v4.0/v2 vectors, or no severity entry) are emitted as `"High"` by the script's `severity_label()` function — a conservative fallback that prevents a real Critical CVE from silently appearing as Medium.
 
 ### Agent tiers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ The key invariant: Block A is posted only when `--create-pr` is passed and no PR
 
 ### Severity normalization
 
-Each agent uses its own severity scale. The skill's `SKILL.md` defines a normalization table (Phase 2) that maps agent-specific scales to a unified Critical/High/Medium/Low scale, and deduplicates findings when two agents flag the same `file:line`.
+Each agent uses its own severity scale. The skill's `SKILL.md` defines a normalization table (Phase 2) that maps agent-specific scales to a unified Critical/High/Medium/Low scale, and deduplicates findings when two agents flag the same `file:line`. CVE findings with no CVSS score available use a synthetic `Unknown` tier, which normalizes conservatively to High.
 
 ### Agent tiers
 
@@ -94,9 +94,11 @@ Agents are divided into four tiers:
 1. **Always-run:** pr-summarizer, code-reviewer — run in every mode including `--quick`
 2. **Full-run only (skip with `--quick`):** architecture-reviewer, security-reviewer, blind-hunter, edge-case-hunter, comment-analyzer, type-design-analyzer, issue-linker (also skipped with `--pr`, `--no-post`/`--local`, and on non-GitHub repos)
 3. **Conditional (run in both full and `--quick` when triggered by diff content):** silent-failure-hunter (error patterns), pr-test-analyzer (test files)
-4. **Deterministic (non-agent, conditional on manifest files):** `dependency-check` via `scripts/run-cve-check.sh` — runs in both full and `--quick` when `go.mod`, `package.json`, `requirements.txt`, or `composer.json` appear in the diff
+4. **Deterministic (non-agent, conditional on manifest files):** `dependency-check` via `scripts/run-cve-check.sh` — runs in both full and `--quick` when `go.mod`, `package.json`, `requirements*.txt`, or `composer.json` appear in the diff
 
-The `--quick` flag eliminates the two expensive Opus review agents, the two BMAD-inspired Sonnet agents (blind-hunter, edge-case-hunter), and the lower-value conditional agents, reducing cost by ~75% while preserving the core code review and error/test analysis.
+The `--quick` flag eliminates the two expensive Opus review agents, the two BMAD-inspired Sonnet agents (blind-hunter, edge-case-hunter), and the lower-value conditional agents, reducing cost by roughly 60–80% while preserving the core code review and error/test analysis.
+
+The `--depth deep` flag promotes blind-hunter and edge-case-hunter to Opus 4.7, enables extended step-by-step reasoning for architecture-reviewer and security-reviewer, and adds a Phase 1c CVE reachability triage pass that annotates each CVE finding with `reachability: reachable|dev-only|transitive-only|unknown`. Defaults are unchanged when `--depth` is omitted.
 
 ### claude-mem integration (optional)
 
@@ -176,6 +178,7 @@ install.sh                             ← legacy file-copy installer (recommend
 - When adding a new agent to the skill, add it to: the agent roster table in `README.md`, the Phase 1 launch conditions in `SKILL.md`, and the severity normalization table in `SKILL.md` if it uses a non-standard scale.
 - The `allowed-tools` frontmatter in `SKILL.md` controls which tools the orchestrator can use. When adding GitHub write operations, add the corresponding `mcp__github-pat__*` tool there.
 - When modifying `--quick` or `--diagrams` behavior, update the mode flag table in Phase 1 of `SKILL.md`, the flags section at the top of `SKILL.md`, the flags table in `README.md`, and `HELP.md`.
+- When adding a new flag, update: the flags parse block in `SKILL.md` (Phase 0, L32–46 area), the mode table in `SKILL.md` (Phase 1 L242–250 area), the flags table in `README.md`, and `HELP.md`.
 - **blind-hunter** has a unique context constraint: it must receive ONLY the diff or plain file list — no manifest, no project context, no commit log. If you change the context-passing strategy in `SKILL.md`, verify blind-hunter's constraint is still enforced. The agent file itself also instructs the agent to ignore any extra context it receives.
 - When modifying provider-specific behavior, update the Provider Operations Reference block, all three provider branches (github/gitlab/bitbucket) within Phases 0, 4, and 4b, and the provider support matrix in README.md.
 - **BMAD attribution**: `blind-hunter` and `edge-case-hunter` were adapted from BMAD-METHOD (MIT License, BMad Code LLC). Attribution is present in both agent files and in README.md. Do not remove attribution when editing these agents.

--- a/README.md
+++ b/README.md
@@ -155,9 +155,10 @@ Run from any git repository, on the branch you want to review:
 | Flag | Effect |
 |------|--------|
 | `--base <branch>` | Compare against a specific base branch (default: auto-detected upstream or `main`) |
-| `--quick` | Fast mode: pr-summarizer + code-reviewer + triggered error/test agents only. Skips security, architecture, blind-hunter, edge-case-hunter, comment, and type analysis. ~75% cheaper. |
+| `--quick` | Fast mode: pr-summarizer + code-reviewer + triggered error/test agents only. Skips security, architecture, blind-hunter, edge-case-hunter, comment, and type analysis. Roughly 60–80% cheaper depending on diff composition. |
 | `--diagrams` | Include Mermaid sequence diagrams in Block A. Default is omitted (saves hundreds of output tokens). Always omitted in `--quick`. |
-| `--security-only` | Run only the security-reviewer agent |
+| `--security-only` | Run security-reviewer + CVE check on changed dependency manifests only |
+| `--depth <tier>` | Agent depth: `normal` (default) or `deep`. In `deep` mode, blind-hunter and edge-case-hunter run on Opus 4.7, Opus agents use extended step-by-step reasoning, and a CVE reachability triage pass annotates which vulnerabilities are reachable in the diff. |
 | `--summary-only` | Run only the pr-summarizer agent |
 | `--create-pr` | Create a PR using Block A as the description. Without this flag, no PR is created. |
 | `--post-summary` | Post Block A (summary) as a comment on an existing PR/MR |
@@ -178,7 +179,7 @@ Run from any git repository, on the branch you want to review:
 # Review and create a PR with the summary as its description
 /comprehensive-review --create-pr
 
-# Fast review — ~75% cheaper, skips security and architecture agents
+# Fast review — roughly 60–80% cheaper, skips security and architecture agents
 /comprehensive-review --quick --local
 
 # Review your own open PR and share findings with co-reviewers
@@ -199,8 +200,11 @@ Run from any git repository, on the branch you want to review:
 # Review against a non-default base
 /comprehensive-review --base develop
 
-# Security scan only
+# Security scan only (includes CVE check on changed dependency manifests)
 /comprehensive-review --security-only --local
+
+# Deep review — Opus 4.7 for all agents + extended reasoning + CVE reachability triage
+/comprehensive-review --depth deep
 ```
 
 ## Posting behavior
@@ -223,7 +227,7 @@ Run from any git repository, on the branch you want to review:
 
 ## Agent roster
 
-Opus agents (`architecture-reviewer`, `security-reviewer`) use the `opus` alias, which the Claude Code harness resolves to the current Opus model.
+Opus agents (`architecture-reviewer`, `security-reviewer`) use the `opus` alias, which the Claude Code harness resolves to the current Opus model (Opus 4.7 as of this release). In `--depth deep` mode, `blind-hunter` and `edge-case-hunter` also run on Opus 4.7.
 
 ### Full run
 
@@ -247,7 +251,7 @@ In addition to LLM agents, the skill runs a deterministic CVE check when depende
 
 | Check | Trigger | Runs in `--quick`? |
 |-------|---------|-------------------|
-| **dependency-check** — queries [OSV.dev](https://osv.dev/) for known vulnerabilities in declared dependency versions | `go.mod`, `package.json`, `requirements.txt`, or `composer.json` changed | Yes |
+| **dependency-check** — queries [OSV.dev](https://osv.dev/) for known vulnerabilities in declared dependency versions | `go.mod`, `package.json`, `requirements*.txt`, or `composer.json` changed | Yes |
 
 No API key required. Network failures are non-blocking (returns empty, warns to stderr). Findings appear in Block B as `[dependency-check]` entries.
 
@@ -327,7 +331,7 @@ The skill uses a tiered context-passing strategy to minimize token consumption:
 - **Medium/large diffs (300+ lines):** Custom agents receive a structured file manifest and read specific files on demand. Toolkit agents receive only the diff slices relevant to their specialty.
 - **Pre-flight context sharing:** The orchestrator reads CLAUDE.md and the commit log once in Phase 0 and passes condensed versions to agents, eliminating redundant reads.
 - **Agent scope boundaries:** Explicit boundaries prevent duplicate analysis across agents (e.g., security-reviewer handles dependency security, architecture-reviewer handles dependency architecture).
-- **`--quick` mode:** Skips the two Opus review agents (architecture-reviewer, security-reviewer), the two BMAD-inspired agents (blind-hunter, edge-case-hunter), and the two lower-value conditional agents (comment-analyzer, type-design-analyzer). Reduces cost by ~75% vs. full run (measured: ~79K agent tokens for --quick vs ~317K for a full run on a documentation PR; code-heavy PRs with deeper Opus analysis yield higher savings).
+- **`--quick` mode:** Skips the two Opus review agents (architecture-reviewer, security-reviewer), the two BMAD-inspired agents (blind-hunter, edge-case-hunter), and the two lower-value conditional agents (comment-analyzer, type-design-analyzer). Roughly 60–80% cheaper vs. full run depending on diff composition (measured: ~79K agent tokens for --quick vs ~317K for a full run on a documentation PR; code-heavy PRs with deeper Opus analysis yield higher savings).
 - **blind-hunter cost:** Particularly cheap — it receives only the raw diff or plain file list, with no project context passed at all.
 
 ## claude-mem integration (optional)

--- a/agents/architecture-reviewer.md
+++ b/agents/architecture-reviewer.md
@@ -12,6 +12,12 @@ You are a senior software architect reviewing code changes through a strategic l
 not to find individual bugs, but to assess whether the design decisions will serve
 the project well over time.
 
+When `EXTENDED_THINKING=true` is set in the task description, reason step-by-step through
+each architectural lens before emitting findings: name the 2–3 most consequential design
+decisions in the diff, evaluate each one explicitly, then assess the cumulative impact.
+This produces higher-quality assessments by grounding conclusions in explicit trade-off
+analysis rather than surface-level pattern recognition.
+
 ## Your Task
 
 You will receive a file manifest (which includes the base branch), commit log, and condensed project

--- a/agents/architecture-reviewer.md
+++ b/agents/architecture-reviewer.md
@@ -19,6 +19,11 @@ context. Use `git diff <base>...HEAD -- <file>` to read specific files relevant 
 architectural analysis. Prioritize files that introduce new abstractions, modify public
 APIs, change dependency relationships, or restructure modules.
 
+If the file manifest is missing or empty, fall back to
+`git diff --name-only @{u}...HEAD 2>/dev/null || git diff --name-only main...HEAD`
+to discover changed files. If that also fails, output EXACTLY the word `NONE` — do not
+fabricate findings.
+
 ## Architectural Review Lenses
 
 ### 1. Design Patterns and Conventions
@@ -119,5 +124,3 @@ If you have no findings at Medium or higher, output EXACTLY the word `NONE` and 
 ```
 
 If there are no findings at a severity level, omit that level's subsection.
-If you find no issues worth reporting, say so explicitly: "This change is architecturally
-sound. No significant concerns identified."

--- a/agents/blind-hunter.md
+++ b/agents/blind-hunter.md
@@ -130,8 +130,7 @@ Reviewed <N> files / <N> lines of diff with no project context.
 - <things that were clear and well-written even without context>
 ```
 
-Omit any severity section that has no findings. If you find no issues:
-"No issues identified from a context-free reading of this diff. Reviewed <N> files."
+Omit any severity section that has no findings.
 
 Keep findings grounded in what the diff shows. Do not speculate beyond what is visible.
 

--- a/agents/edge-case-hunter.md
+++ b/agents/edge-case-hunter.md
@@ -97,7 +97,7 @@ If no gaps survive Pass 2, output EXACTLY the word `NONE` and nothing else.
 ### Pass 1: Path Walk
 
 Traced <N> functions/methods across <M> files. Found <P> branching constructs.
-<C> candidates identified; <F> confirmed as findings after Pass 2, <D> discarded.
+<C> candidates identified; <F> confirmed as findings after Pass 2, <D> discarded (ruled out by Pass 2).
 
 ### Pass 2: Validated Findings
 

--- a/agents/edge-case-hunter.md
+++ b/agents/edge-case-hunter.md
@@ -28,6 +28,8 @@ condensed project context. Use `git diff <base>...HEAD -- <file>` to read specif
 relevant to your analysis — focus on files with control flow (source files, not docs or
 configs). You may also use the Read tool to examine surrounding code context outside the
 diff when you need to understand whether a gap is handled by an enclosing scope or caller.
+Cap Read usage at 10 total calls per run, at most 200 lines per call. If you need
+broader context, prefer `git diff <base>...HEAD -- <file>` to stay bounded to the diff.
 
 ## Two-Pass Analysis
 
@@ -95,7 +97,7 @@ If no gaps survive Pass 2, output EXACTLY the word `NONE` and nothing else.
 ### Pass 1: Path Walk
 
 Traced <N> functions/methods across <M> files. Found <P> branching constructs.
-<N> candidates identified; <M> confirmed as findings after Pass 2, <K> discarded.
+<C> candidates identified; <F> confirmed as findings after Pass 2, <D> discarded.
 
 ### Pass 2: Validated Findings
 
@@ -120,8 +122,7 @@ Traced <N> functions/methods across <M> files. Found <P> branching constructs.
 - <well-handled edge cases worth noting>
 ```
 
-Omit any severity section that has no findings. If no gaps survive Pass 2:
-"All branching paths in the changed code are handled. Traced <N> functions across <M> files."
+Omit any severity section that has no findings.
 
 ---
 

--- a/agents/pr-summarizer.md
+++ b/agents/pr-summarizer.md
@@ -48,11 +48,15 @@ Effort: 1=trivial 2=small(<50L) 3=medium(50-200L) 4=large(200-500L/schema) 5=maj
 **Summary**: single short phrase describing what changed in that file (not what the
 file does in general). Sort by most significant changes first, then alphabetically.
 
-## Step 4: Generate `## Sequence Diagrams`
+## Step 4: Generate `## Sequence Diagrams` (only when `DIAGRAMS=true`)
 
-For each file modifying **control flow** (function call chains, API interactions, error
-paths, event handling), generate a Mermaid `sequenceDiagram` block showing the flow
-**after** the change.
+**Only generate this section if the orchestrator passed `DIAGRAMS=true` in the task
+description. If `DIAGRAMS=false` or no `DIAGRAMS` flag was provided, omit the
+`## Sequence Diagrams` heading and its content entirely.**
+
+When generating diagrams: for each file modifying **control flow** (function call chains,
+API interactions, error paths, event handling), generate a Mermaid `sequenceDiagram` block
+showing the flow **after** the change.
 
 Skip files that are purely data structures, configuration, documentation, test fixtures,
 or minor cosmetic edits. If no files have meaningful control flow changes, write:
@@ -82,6 +86,7 @@ Produce exactly these sections in order, with no preamble:
 
 ## Sequence Diagrams
 
+<!-- Only present when DIAGRAMS=true; omit this section otherwise -->
 <diagrams or "No significant control flow changes in this PR.">
 
 ## Related Issues & PRs

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -23,7 +23,8 @@ Use `git diff <base>...HEAD -- <file>` to read specific files, prioritizing:
 auth/authorization files, crypto usage, input handling, dependency files, and any file
 whose name or path suggests security relevance.
 
-If the file manifest is missing or incomplete, fall back to `git diff --name-only HEAD~1...HEAD`
+If the file manifest is missing or incomplete, fall back to
+`git diff --name-only @{u}...HEAD 2>/dev/null || git diff --name-only main...HEAD || git diff --name-only master...HEAD`
 to discover changed files. If you cannot determine the base branch, state this explicitly:
 "WARNING: Base branch not provided. Analysis may be incomplete."
 Never produce a clean report if you were unable to examine the diff.
@@ -132,8 +133,6 @@ are not reporting in detail, add a summary count at the end of the Findings sect
 ```
 
 If there are no findings at a severity level, omit that subsection.
-If you find no security issues, say so explicitly: "No security vulnerabilities identified
-in the changed code. Reviewed N files across M security check categories."
 
 Do not report issues on unchanged lines, pre-existing code, or in test fixtures unless
 the test fixtures could be mistakenly copied into production use.

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -15,6 +15,12 @@ vulnerabilities. You have deep knowledge of OWASP Top 10, language-specific secu
 pitfalls, and supply chain security. You treat security issues as First Law violations —
 always err on the side of reporting. A false positive is better than a missed vulnerability.
 
+When `EXTENDED_THINKING=true` is set in the task description, reason step-by-step through
+each security check category before emitting findings: trace data flows from trust
+boundaries, evaluate each injection surface explicitly, and verify auth paths in sequence.
+This produces higher-quality output by grounding findings in reasoned paths rather than
+pattern-matching alone.
+
 ## Your Task
 
 Analyze the changed code for security vulnerabilities. You will receive a file manifest,

--- a/scripts/run-cve-check.sh
+++ b/scripts/run-cve-check.sh
@@ -82,7 +82,10 @@ query_osv_batch() {
       _OSV_MOCK_WARNED=1
     fi
     if [[ -r "$OSV_MOCK_FILE" ]]; then
-      cat "$OSV_MOCK_FILE" || echo ""
+      if ! cat "$OSV_MOCK_FILE"; then
+        echo "WARNING: OSV_MOCK_FILE set but could not be read: ${OSV_MOCK_FILE}" >&2
+        echo ""
+      fi
       return 0
     fi
     echo "WARNING: OSV_MOCK_FILE set but not readable: ${OSV_MOCK_FILE}" >&2
@@ -90,17 +93,22 @@ query_osv_batch() {
     return 0
   fi
 
-  local body osv_response curl_exit
-  body=$(jq -n --argjson q "$queries_json" '{queries: $q}')
+  local body body_err osv_response curl_exit
+  if ! body=$(jq -n --argjson q "$queries_json" '{queries: $q}' 2>&1); then
+    body_err="$body"
+    echo "WARNING: Failed to build OSV batch request body: ${body_err}" >&2
+    echo ""
+    return 0
+  fi
 
   osv_response=$(curl -sS --fail-with-body --max-time 30 --max-filesize 52428800 \
-    --retry 2 --retry-delay 1 \
+    --retry 2 --retry-delay 1 --retry-all-errors \
     -H 'Content-Type: application/json' \
     -X POST "$OSV_API_URL" \
     -d "$body" 2>/dev/null)
   curl_exit=$?
   if [[ $curl_exit -ne 0 ]]; then
-    echo "WARNING: OSV batch API request failed (curl exit ${curl_exit})" >&2
+    echo "WARNING: OSV batch API request failed (curl exit ${curl_exit}) for packages ${_batch_start_ref:-?}–${_batch_end_ref:-?} of ${ATTEMPTED}" >&2
     echo ""
     return 0
   fi
@@ -321,7 +329,8 @@ parse_go_mod() {
             gsub(/^[[:space:]]+|[[:space:]]+$/, "", old_part)
             m = split(old_part, of, /[[:space:]]+/)
             old_name = of[1]
-            if (m >= 2) old_name = of[2]  # "replace" keyword is of[1]
+            # Skip past "replace" keyword only on inline directives (not inside a block)
+            if (!in_replace && $1 == "replace" && m >= 2) old_name = of[2]
             new_name = rf[1]
             new_ver = (n >= 2 && rf[2] ~ /^v/) ? substr(rf[2], 2) : ""
             if (old_name != "" && new_name != "" && new_ver != "")
@@ -372,21 +381,25 @@ parse_package_json() {
 }
 
 parse_requirements_txt() {
-  local file="$1"
+  local file="$1" result
   # Accept ==, ===, ~=, >=, <= version specs; extract the anchor version.
   # Unpinned packages (no version spec) are skipped — OSV needs a concrete version.
-  grep -E '^[[:space:]]*[A-Za-z0-9_.-]' "$file" 2>/dev/null \
-    | grep -v '^[[:space:]]*#' \
-    | sed 's/[[:space:]]*#.*//' \
-    | grep -E '(===?|~=|>=|<=)' \
-    | while IFS= read -r line; do
-        line="${line#"${line%%[! ]*}"}"
-        # Strip extras (e.g. requests[security] -> requests)
-        pkg=$(echo "$line" | sed 's/[>=<!~].*//' | sed 's/\[.*\]//' | tr -d ' ')
-        # Extract first version spec value after any of the operators
-        ver=$(echo "$line" | grep -oE '(===?|~=|>=|<=)[[:space:]]*[0-9][^,;[:space:]]*' | head -1 | sed 's/[>=<!~[:space:]]*//')
-        [[ -n "$pkg" && -n "$ver" ]] && printf "PyPI\t%s\t%s\n" "$pkg" "$ver"
-      done
+  if ! result=$(grep -E '^[[:space:]]*[A-Za-z0-9_.-]' "$file" 2>/dev/null \
+      | grep -v '^[[:space:]]*#' \
+      | sed 's/[[:space:]]*#.*//' \
+      | grep -E '(===?|~=|>=|<=)' \
+      | while IFS= read -r line; do
+          line="${line#"${line%%[! ]*}"}"
+          # Strip extras (e.g. requests[security] -> requests)
+          pkg=$(echo "$line" | sed 's/[>=<!~].*//' | sed 's/\[.*\]//' | tr -d ' ')
+          # Extract first version spec value after any of the operators
+          ver=$(echo "$line" | grep -oE '(===?|~=|>=|<=)[[:space:]]*[0-9][^,;[:space:]]*' | head -1 | sed 's/[>=<!~[:space:]]*//')
+          [[ -n "$pkg" && -n "$ver" ]] && printf "PyPI\t%s\t%s\n" "$pkg" "$ver"
+        done 2>&1); then
+    echo "WARNING: Failed to parse ${file}: ${result}" >&2
+    return 0
+  fi
+  echo "$result"
 }
 
 parse_composer_json() {
@@ -477,14 +490,21 @@ while [[ "$batch_start" -lt "$ATTEMPTED" ]]; do
   sep=""
   for (( i=batch_start; i<batch_end; i++ )); do
     eco="${TUPLE_ECO[$i]}" name="${TUPLE_NAME[$i]}" ver="${TUPLE_VER[$i]}"
-    q=$(jq -n --arg eco "$eco" --arg name "$name" --arg ver "$ver" \
-      '{version: $ver, package: {name: $name, ecosystem: $eco}}')
+    q="" q_err=""
+    if ! q=$(jq -n --arg eco "$eco" --arg name "$name" --arg ver "$ver" \
+        '{version: $ver, package: {name: $name, ecosystem: $eco}}' 2>&1); then
+      q_err="$q"
+      echo "WARNING: Failed to build OSV query for ${eco}/${name}@${ver}: ${q_err}" >&2
+      continue
+    fi
+    [[ -z "$q" ]] && { echo "WARNING: Empty OSV query for ${eco}/${name}@${ver}" >&2; continue; }
     queries_json="${queries_json}${sep}${q}"
     sep=","
   done
   queries_json="${queries_json}]"
 
-  # POST batch; fall back to [] on failure (non-blocking)
+  # POST batch; fall back to [] on failure (non-blocking). Pass range context for diagnostics.
+  _batch_start_ref="$batch_start" _batch_end_ref="$batch_end"
   batch_response=$(query_osv_batch "$queries_json")
 
   if [[ -z "$batch_response" ]]; then
@@ -492,17 +512,29 @@ while [[ "$batch_start" -lt "$ATTEMPTED" ]]; do
     continue
   fi
 
-  # Map each response[i] back to its tuple and generate findings
+  # Validate response length matches query count before iterating
   batch_count=$(( batch_end - batch_start ))
+  results_count=$(echo "$batch_response" | jq '.results | length' 2>/dev/null)
+  if [[ -n "$results_count" && "$results_count" -ne "$batch_count" ]]; then
+    echo "WARNING: OSV batch returned ${results_count} results for ${batch_count} queries (index mismatch)" >&2
+  fi
+
+  # Map each response[i] back to its tuple and generate findings
   for (( j=0; j<batch_count; j++ )); do
     i=$(( batch_start + j ))
     eco="${TUPLE_ECO[$i]}" name="${TUPLE_NAME[$i]}" ver="${TUPLE_VER[$i]}"
     file="${TUPLE_FILE[$i]}" tag="${TUPLE_TAG[$i]}"
 
     # Extract the j-th result from the batch response
-    per_pkg_response=$(echo "$batch_response" | jq -c --argjson idx "$j" '.results[$idx] // {}')
-    [[ -z "$per_pkg_response" || "$per_pkg_response" == "{}" ]] && continue
-    CHECKED=$(( CHECKED + 1 ))
+    per_pkg_response="" per_pkg_err=""
+    if ! per_pkg_response=$(echo "$batch_response" | jq -c --argjson idx "$j" '.results[$idx] // {}' 2>&1); then
+      per_pkg_err="$per_pkg_response"
+      echo "WARNING: Failed to extract OSV result[$j] for ${eco}/${name}@${ver}: ${per_pkg_err}" >&2
+      continue
+    fi
+    if [[ -z "$per_pkg_response" ]] || echo "$per_pkg_response" | jq -e '. == {}' >/dev/null 2>&1; then
+      continue
+    fi
 
     local_findings=""
     if ! local_findings=$(osv_to_findings "$file" "$name" "$ver" "$eco" "$per_pkg_response" "$tag" 2>&1); then
@@ -513,6 +545,7 @@ while [[ "$batch_start" -lt "$ATTEMPTED" ]]; do
       echo "WARNING: Unexpected osv_to_findings output for ${eco}/${name}@${ver}" >&2
       continue
     fi
+    CHECKED=$(( CHECKED + 1 ))
     if [[ "$local_findings" != "[]" && -n "$local_findings" ]]; then
       ALL_FINDINGS_STREAM="${ALL_FINDINGS_STREAM}${local_findings}"$'\n'
     fi
@@ -523,7 +556,12 @@ done
 
 # Single merge: combine all per-package finding arrays into one flat array
 if [[ -n "$ALL_FINDINGS_STREAM" ]]; then
-  FINDINGS=$(echo "$ALL_FINDINGS_STREAM" | jq -s 'add // []')
+  merge_err=""
+  if ! FINDINGS=$(echo "$ALL_FINDINGS_STREAM" | jq -s 'add // []' 2>&1); then
+    merge_err="$FINDINGS"
+    echo "WARNING: Failed to merge CVE findings into final array: ${merge_err}" >&2
+    FINDINGS="[]"
+  fi
 else
   FINDINGS="[]"
 fi

--- a/scripts/run-cve-check.sh
+++ b/scripts/run-cve-check.sh
@@ -16,13 +16,17 @@
 #   OSV API is unavailable.
 #
 # Environment:
-#   OSV_MOCK_FILE   When set to a readable file path, read the OSV response
-#                   from that file instead of calling the network. Used for
+#   OSV_MOCK_FILE   When set to a readable file path, read the OSV batch response
+#                   from that file instead of calling the network. The file must
+#                   contain a valid /v1/querybatch JSON response body. Used for
 #                   offline testing; must be unset in production.
-#   OSV_API_URL     Override OSV endpoint (default: https://api.osv.dev/v1/query).
+#   OSV_API_URL     Override OSV endpoint (default: https://api.osv.dev/v1/querybatch).
 #
 # Supported manifests:
-#   go.mod, package.json, requirements.txt, composer.json
+#   go.mod, package.json, requirements*.txt, composer.json
+#
+# Performance: uses OSV /v1/querybatch to POST all packages in a single request
+# rather than one request per package, reducing latency ~100x on large manifests.
 #
 # Adapted from tag1consulting/ai-pr-review (MIT License).
 
@@ -34,7 +38,7 @@ if [[ -n "${1:-}" ]]; then
 else
   CHANGED_FILES=$(cat)
 fi
-OSV_API_URL="${OSV_API_URL:-https://api.osv.dev/v1/query}"
+OSV_API_URL="${OSV_API_URL:-https://api.osv.dev/v1/querybatch}"
 _OSV_MOCK_WARNED=0
 
 if ! command -v jq >/dev/null 2>&1; then
@@ -64,10 +68,13 @@ fi
 
 # --- Helpers -------------------------------------------------------------
 
-# Query OSV.dev for a single package@version. Prints the raw JSON response
-# on stdout, or an empty string on any failure (so callers can short-circuit).
-query_osv() {
-  local ecosystem="$1" name="$2" version="$3"
+# Post a batch of queries to OSV.dev /v1/querybatch. Accepts a JSON array
+# of {version, package} objects on stdin and prints the raw batch response
+# JSON on stdout, or "" on failure.
+#
+# OSV_MOCK_FILE is treated as the literal batch response when set.
+query_osv_batch() {
+  local queries_json="$1"
 
   if [[ -n "${OSV_MOCK_FILE:-}" ]]; then
     if [[ "$_OSV_MOCK_WARNED" -eq 0 ]]; then
@@ -84,25 +91,21 @@ query_osv() {
   fi
 
   local body osv_response curl_exit
-  body=$(jq -n \
-    --arg eco "$ecosystem" \
-    --arg pkg "$name" \
-    --arg ver "$version" \
-    '{version: $ver, package: {name: $pkg, ecosystem: $eco}}')
+  body=$(jq -n --argjson q "$queries_json" '{queries: $q}')
 
-  osv_response=$(curl -sS --fail-with-body --max-time 10 --max-filesize 2097152 \
-    --retry 2 --retry-delay 1 --retry-all-errors \
+  osv_response=$(curl -sS --fail-with-body --max-time 30 --max-filesize 52428800 \
+    --retry 2 --retry-delay 1 \
     -H 'Content-Type: application/json' \
     -X POST "$OSV_API_URL" \
     -d "$body" 2>/dev/null)
   curl_exit=$?
   if [[ $curl_exit -ne 0 ]]; then
-    echo "WARNING: OSV API request failed (curl exit ${curl_exit}) for ${ecosystem}/${name}@${version}" >&2
+    echo "WARNING: OSV batch API request failed (curl exit ${curl_exit})" >&2
     echo ""
     return 0
   fi
-  if ! echo "$osv_response" | jq -e 'type == "object"' >/dev/null 2>&1; then
-    echo "WARNING: OSV API returned non-JSON for ${ecosystem}/${name}@${version}" >&2
+  if ! echo "$osv_response" | jq -e 'type == "object" and has("results")' >/dev/null 2>&1; then
+    echo "WARNING: OSV batch API returned unexpected response" >&2
     echo ""
     return 0
   fi
@@ -128,8 +131,8 @@ line_for_package() {
       pattern="[[:space:]]${escaped}[[:space:]]"
       line=$(grep -n -E -m 1 -- "$pattern" "$file" 2>/dev/null | cut -d: -f1)
       ;;
-    requirements.txt)
-      pattern="^[[:space:]]*${escaped}[[:space:]]*(==|\\[|\$)"
+    requirements*.txt)
+      pattern="^[[:space:]]*${escaped}[[:space:]]*(===?|~=|>=|<=|==|\\[|\$)"
       line=$(grep -n -E -m 1 -- "$pattern" "$file" 2>/dev/null | cut -d: -f1)
       ;;
     *)
@@ -209,12 +212,16 @@ osv_to_findings() {
           end
         end;
 
-    # Extract a numeric score from an OSV severity entry.
-    # Real OSV responses put the CVSS vector alone in .score; legacy/test
-    # fixtures may include a trailing "(9.8)" or a bare number. Try each.
+    # Extract a numeric score from an OSV severity entry score string.
+    # Supports CVSS v3.x vectors (full formula), CVSS v4.0/v2 (null, see
+    # severity_label for conservative fallback), bare numerics, and "(9.8)" form.
     def parse_score($s):
       ( if ($s | type) != "string" then null
         elif ($s | test("^CVSS:3"; "i")) then cvss_v3_score($s)
+        elif ($s | test("^CVSS:[24]"; "i")) then
+          # v4.0: formula is too complex for jq; v2: deprecated.
+          # Return null — severity_label will map null → High (conservative).
+          null
         elif ($s | test("\\([0-9]+(\\.[0-9]+)?\\)"))
           then ($s | capture("\\((?<n>[0-9]+(\\.[0-9]+)?)\\)").n | tonumber)
         elif ($s | test("^[0-9]+(\\.[0-9]+)?$"))
@@ -226,15 +233,24 @@ osv_to_findings() {
         | map(parse_score(.)) | map(select(. != null))
         | if length > 0 then max else null end );
 
-    # Severity mapping. When CVSS cannot be parsed we fail safe to Medium,
-    # not Low, so a novel score format does not silently downgrade a real
-    # Critical CVE below the reviewer-noticeable tier.
+    # Severity mapping. When CVSS cannot be parsed (null — occurs for CVSS v4
+    # and v2 vectors and unknown formats) we fail safe to High, not Medium.
+    # This prevents a v4.0 Critical CVE from silently appearing as Medium.
     def severity_label($cvss):
-      if $cvss == null then "Medium"
+      if $cvss == null then "High"
       elif $cvss >= 9.0 then "Critical"
       elif $cvss >= 7.0 then "High"
       elif $cvss >= 4.0 then "Medium"
       else "Low" end;
+
+    def cvss_display($cvss; $entries):
+      # Show score when we have it; show version prefix otherwise.
+      if $cvss != null then "CVSS \(($cvss * 10 | round) / 10)"
+      else
+        ( $entries | [.[].score // ""] | map(select(test("^CVSS:";"i")))
+          | if length > 0 then .[0] | capture("^(?<v>CVSS:[^/]+)") | .v
+            else "CVSS:unknown" end )
+      end;
 
     # Pick the first fixed version from affected entries that match the
     # queried package name + ecosystem. Falls back to scanning all affected
@@ -252,14 +268,21 @@ osv_to_findings() {
       ( [.aliases[]? | select(startswith("CVE-"))] | first // .id );
 
     [ .vulns[]? as $v | $v |
+      (.severity // []) as $sev_entries |
       (pick_cvss) as $score |
+      (fixed_version) as $fix |
       {
         severity: severity_label($score),
         agent: "dependency-check",
         file: $file,
         line: $line,
-        finding: ("\(cve_id) (\($v.id)): \($v.summary // $v.details // "Known vulnerability"). Affects \($pkg)@\($ver)\(if $deptag == "dev" then " (dev dependency)" else "" end)."),
-        remediation: ("Upgrade \($pkg) to \(fixed_version) or later. See https://osv.dev/vulnerability/\($v.id)")
+        finding: ("\(cve_id) (\($v.id)) [\(cvss_display($score; $sev_entries))]: \($v.summary // $v.details // "Known vulnerability"). Affects \($pkg)@\($ver)\(if $deptag == "dev" then " (dev dependency)" else "" end)."),
+        remediation: (
+          if $fix == "unknown"
+          then "No fixed version published yet. Monitor https://osv.dev/vulnerability/\($v.id) for mitigations and workarounds."
+          else "Upgrade \($pkg) to \($fix) or later. See https://osv.dev/vulnerability/\($v.id)"
+          end
+        )
       }
     ]
   '
@@ -395,21 +418,29 @@ is_queryable_version() {
   return 0
 }
 
-# --- Main loop -----------------------------------------------------------
+# --- Main loop (two-pass batch) ------------------------------------------
+#
+# Pass A: collect all queryable (ecosystem, name, version, manifest, deptag)
+#         tuples across all manifests into parallel arrays.
+#
+# Pass B: POST all tuples to /v1/querybatch in one request (up to 1000 per
+#         batch), map the indexed responses back to their tuples, and
+#         accumulate findings into a single newline-delimited stream.
+#         Final merge is one jq -s call — O(1), not O(n²).
 
-FINDINGS="[]"
-CHECKED=0
+declare -a TUPLE_ECO TUPLE_NAME TUPLE_VER TUPLE_FILE TUPLE_TAG
 ATTEMPTED=0
+CHECKED=0
 
 for manifest in "${MANIFEST_FILES[@]}"; do
   base=$(basename "$manifest")
 
   case "$base" in
-    go.mod)          packages=$(parse_go_mod "$manifest") ;;
-    package.json)    packages=$(parse_package_json "$manifest") ;;
+    go.mod)            packages=$(parse_go_mod "$manifest") ;;
+    package.json)      packages=$(parse_package_json "$manifest") ;;
     requirements*.txt) packages=$(parse_requirements_txt "$manifest") ;;
-    composer.json)   packages=$(parse_composer_json "$manifest") ;;
-    *)               continue ;;
+    composer.json)     packages=$(parse_composer_json "$manifest") ;;
+    *)                 continue ;;
   esac
 
   [[ -z "$packages" ]] && continue
@@ -417,36 +448,87 @@ for manifest in "${MANIFEST_FILES[@]}"; do
   while IFS=$'\t' read -r ecosystem name version deptag; do
     [[ -z "$ecosystem" || -z "$name" || -z "$version" ]] && continue
     is_queryable_version "$version" || continue
-
+    TUPLE_ECO+=("$ecosystem")
+    TUPLE_NAME+=("$name")
+    TUPLE_VER+=("$version")
+    TUPLE_FILE+=("$manifest")
+    TUPLE_TAG+=("${deptag:-}")
     ATTEMPTED=$(( ATTEMPTED + 1 ))
-
-    response=$(query_osv "$ecosystem" "$name" "$version")
-    [[ -z "$response" ]] && continue
-    CHECKED=$(( CHECKED + 1 ))
-
-    local_findings=""
-    if ! local_findings=$(osv_to_findings "$manifest" "$name" "$version" "$ecosystem" "$response" "${deptag:-}" 2>&1); then
-      echo "WARNING: Failed to parse OSV findings for ${ecosystem}/${name}@${version}: ${local_findings}" >&2
-      continue
-    fi
-    if ! echo "$local_findings" | jq -e 'type == "array"' >/dev/null 2>&1; then
-      echo "WARNING: Unexpected osv_to_findings output for ${ecosystem}/${name}@${version}" >&2
-      continue
-    fi
-
-    if [[ "$local_findings" != "[]" && -n "$local_findings" ]]; then
-      merged=""
-      if ! merged=$(jq -n --argjson a "$FINDINGS" --argjson b "$local_findings" '$a + $b' 2>&1); then
-        echo "WARNING: Failed to merge findings for ${ecosystem}/${name}@${version}: ${merged}" >&2
-      else
-        FINDINGS="$merged"
-      fi
-    fi
   done <<<"$packages"
 done
 
+# Emit [] immediately if nothing to query
+if [[ "$ATTEMPTED" -eq 0 ]]; then
+  echo "[]"
+  exit 0
+fi
+
+# Batch size limit per OSV docs (1000 queries per request)
+BATCH_SIZE=1000
+ALL_FINDINGS_STREAM=""
+
+batch_start=0
+while [[ "$batch_start" -lt "$ATTEMPTED" ]]; do
+  batch_end=$(( batch_start + BATCH_SIZE ))
+  [[ "$batch_end" -gt "$ATTEMPTED" ]] && batch_end="$ATTEMPTED"
+
+  # Build the batch query JSON for this slice
+  queries_json="["
+  sep=""
+  for (( i=batch_start; i<batch_end; i++ )); do
+    eco="${TUPLE_ECO[$i]}" name="${TUPLE_NAME[$i]}" ver="${TUPLE_VER[$i]}"
+    q=$(jq -n --arg eco "$eco" --arg name "$name" --arg ver "$ver" \
+      '{version: $ver, package: {name: $name, ecosystem: $eco}}')
+    queries_json="${queries_json}${sep}${q}"
+    sep=","
+  done
+  queries_json="${queries_json}]"
+
+  # POST batch; fall back to [] on failure (non-blocking)
+  batch_response=$(query_osv_batch "$queries_json")
+
+  if [[ -z "$batch_response" ]]; then
+    batch_start="$batch_end"
+    continue
+  fi
+
+  # Map each response[i] back to its tuple and generate findings
+  batch_count=$(( batch_end - batch_start ))
+  for (( j=0; j<batch_count; j++ )); do
+    i=$(( batch_start + j ))
+    eco="${TUPLE_ECO[$i]}" name="${TUPLE_NAME[$i]}" ver="${TUPLE_VER[$i]}"
+    file="${TUPLE_FILE[$i]}" tag="${TUPLE_TAG[$i]}"
+
+    # Extract the j-th result from the batch response
+    per_pkg_response=$(echo "$batch_response" | jq -c --argjson idx "$j" '.results[$idx] // {}')
+    [[ -z "$per_pkg_response" || "$per_pkg_response" == "{}" ]] && continue
+    CHECKED=$(( CHECKED + 1 ))
+
+    local_findings=""
+    if ! local_findings=$(osv_to_findings "$file" "$name" "$ver" "$eco" "$per_pkg_response" "$tag" 2>&1); then
+      echo "WARNING: Failed to parse OSV findings for ${eco}/${name}@${ver}: ${local_findings}" >&2
+      continue
+    fi
+    if ! echo "$local_findings" | jq -e 'type == "array"' >/dev/null 2>&1; then
+      echo "WARNING: Unexpected osv_to_findings output for ${eco}/${name}@${ver}" >&2
+      continue
+    fi
+    if [[ "$local_findings" != "[]" && -n "$local_findings" ]]; then
+      ALL_FINDINGS_STREAM="${ALL_FINDINGS_STREAM}${local_findings}"$'\n'
+    fi
+  done
+
+  batch_start="$batch_end"
+done
+
+# Single merge: combine all per-package finding arrays into one flat array
+if [[ -n "$ALL_FINDINGS_STREAM" ]]; then
+  FINDINGS=$(echo "$ALL_FINDINGS_STREAM" | jq -s 'add // []')
+else
+  FINDINGS="[]"
+fi
+
 if [[ "$ATTEMPTED" -gt 0 ]]; then
-  # ATTEMPTED = packages with queryable versions; CHECKED = packages that received an OSV response
   echo "CVE check: queried ${CHECKED}/${ATTEMPTED} package versions" >&2
 fi
 

--- a/scripts/run-cve-check.sh
+++ b/scripts/run-cve-check.sh
@@ -48,7 +48,10 @@ MANIFEST_FILES=()
 while IFS= read -r file; do
   [[ -z "$file" ]] && continue
   case "$(basename "$file")" in
-    go.mod|package.json|requirements.txt|composer.json)
+    go.mod|package.json|composer.json)
+      [[ -f "$file" ]] && MANIFEST_FILES+=("$file")
+      ;;
+    requirements*.txt)
       [[ -f "$file" ]] && MANIFEST_FILES+=("$file")
       ;;
   esac
@@ -267,20 +270,58 @@ osv_to_findings() {
 
 parse_go_mod() {
   local file="$1" result
+  # Honor `replace` directives: if a module is replaced, query the replacement
+  # (not the original) to avoid false-positive CVEs on forked/patched modules.
+  # Local-path replaces (starting with . or /) are skipped entirely.
   if ! result=$(awk '
     /^require[[:space:]]+\(/ { in_block=1; next }
     in_block && /^\)/ { in_block=0; next }
+    /^replace[[:space:]]+\(/ { in_replace=1; next }
+    in_replace && /^\)/ { in_replace=0; next }
     {
       line=$0
       sub(/\/\/.*$/, "", line)
       gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
       if (line == "") next
+
+      # Parse replace directives: "old [oldver] => new newver"
+      if (in_replace || $1 == "replace") {
+        # Find the => separator
+        arrow = index(line, "=>")
+        if (arrow > 0) {
+          rhs = substr(line, arrow + 2)
+          gsub(/^[[:space:]]+/, "", rhs)
+          n = split(rhs, rf, /[[:space:]]+/)
+          # Skip local-path replacements (start with . or /)
+          if (n >= 1 && rf[1] !~ /^[.\/]/) {
+            old_part = substr(line, 1, arrow - 1)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", old_part)
+            m = split(old_part, of, /[[:space:]]+/)
+            old_name = of[1]
+            if (m >= 2) old_name = of[2]  # "replace" keyword is of[1]
+            new_name = rf[1]
+            new_ver = (n >= 2 && rf[2] ~ /^v/) ? substr(rf[2], 2) : ""
+            if (old_name != "" && new_name != "" && new_ver != "")
+              replaces[old_name] = new_name SUBSEP new_ver
+          }
+        }
+        next
+      }
+
       if (in_block) {
         n = split(line, f, /[[:space:]]+/)
-        if (n >= 2 && f[2] ~ /^v/) printf "Go\t%s\t%s\n", f[1], substr(f[2], 2)
+        if (n >= 2 && f[2] ~ /^v/) {
+          name = f[1]; ver = substr(f[2], 2)
+          if (name in replaces) { split(replaces[name], r, SUBSEP); name = r[1]; ver = r[2] }
+          printf "Go\t%s\t%s\n", name, ver
+        }
       } else if ($1 == "require") {
         n = split(line, f, /[[:space:]]+/)
-        if (n >= 3 && f[3] ~ /^v/) printf "Go\t%s\t%s\n", f[2], substr(f[3], 2)
+        if (n >= 3 && f[3] ~ /^v/) {
+          name = f[2]; ver = substr(f[3], 2)
+          if (name in replaces) { split(replaces[name], r, SUBSEP); name = r[1]; ver = r[2] }
+          printf "Go\t%s\t%s\n", name, ver
+        }
       }
     }
   ' "$file" 2>&1); then
@@ -309,16 +350,18 @@ parse_package_json() {
 
 parse_requirements_txt() {
   local file="$1"
+  # Accept ==, ===, ~=, >=, <= version specs; extract the anchor version.
+  # Unpinned packages (no version spec) are skipped — OSV needs a concrete version.
   grep -E '^[[:space:]]*[A-Za-z0-9_.-]' "$file" 2>/dev/null \
     | grep -v '^[[:space:]]*#' \
     | sed 's/[[:space:]]*#.*//' \
-    | { grep '==' || true; } \
+    | grep -E '(===?|~=|>=|<=)' \
     | while IFS= read -r line; do
-        # Strip leading whitespace
         line="${line#"${line%%[! ]*}"}"
         # Strip extras (e.g. requests[security] -> requests)
-        pkg=$(echo "$line" | cut -d= -f1 | sed 's/\[.*\]//' | tr -d ' ')
-        ver=$(echo "$line" | sed 's/.*==//' | sed 's/[[:space:]].*//')
+        pkg=$(echo "$line" | sed 's/[>=<!~].*//' | sed 's/\[.*\]//' | tr -d ' ')
+        # Extract first version spec value after any of the operators
+        ver=$(echo "$line" | grep -oE '(===?|~=|>=|<=)[[:space:]]*[0-9][^,;[:space:]]*' | head -1 | sed 's/[>=<!~[:space:]]*//')
         [[ -n "$pkg" && -n "$ver" ]] && printf "PyPI\t%s\t%s\n" "$pkg" "$ver"
       done
 }
@@ -364,7 +407,7 @@ for manifest in "${MANIFEST_FILES[@]}"; do
   case "$base" in
     go.mod)          packages=$(parse_go_mod "$manifest") ;;
     package.json)    packages=$(parse_package_json "$manifest") ;;
-    requirements.txt) packages=$(parse_requirements_txt "$manifest") ;;
+    requirements*.txt) packages=$(parse_requirements_txt "$manifest") ;;
     composer.json)   packages=$(parse_composer_json "$manifest") ;;
     *)               continue ;;
   esac

--- a/scripts/run-cve-check.sh
+++ b/scripts/run-cve-check.sh
@@ -384,7 +384,11 @@ parse_requirements_txt() {
   local file="$1" result
   # Accept ==, ===, ~=, >=, <= version specs; extract the anchor version.
   # Unpinned packages (no version spec) are skipped — OSV needs a concrete version.
-  if ! result=$(grep -E '^[[:space:]]*[A-Za-z0-9_.-]' "$file" 2>/dev/null \
+  # Use a subshell with pipefail disabled so grep exit-1 (no match) is not
+  # treated as an error — it simply means no pinned packages in this file.
+  result=$(
+    set +o pipefail
+    grep -E '^[[:space:]]*[A-Za-z0-9_.-]' "$file" 2>/dev/null \
       | grep -v '^[[:space:]]*#' \
       | sed 's/[[:space:]]*#.*//' \
       | grep -E '(===?|~=|>=|<=)' \
@@ -395,10 +399,8 @@ parse_requirements_txt() {
           # Extract first version spec value after any of the operators
           ver=$(echo "$line" | grep -oE '(===?|~=|>=|<=)[[:space:]]*[0-9][^,;[:space:]]*' | head -1 | sed 's/[>=<!~[:space:]]*//')
           [[ -n "$pkg" && -n "$ver" ]] && printf "PyPI\t%s\t%s\n" "$pkg" "$ver"
-        done 2>&1); then
-    echo "WARNING: Failed to parse ${file}: ${result}" >&2
-    return 0
-  fi
+        done
+  ) || true
   echo "$result"
 }
 
@@ -515,7 +517,8 @@ while [[ "$batch_start" -lt "$ATTEMPTED" ]]; do
   # Validate response length matches query count before iterating
   batch_count=$(( batch_end - batch_start ))
   results_count=$(echo "$batch_response" | jq '.results | length' 2>/dev/null)
-  if [[ -n "$results_count" && "$results_count" -ne "$batch_count" ]]; then
+  # Validate results_count is a non-negative integer before arithmetic comparison
+  if [[ "$results_count" =~ ^[0-9]+$ && "$results_count" -ne "$batch_count" ]]; then
     echo "WARNING: OSV batch returned ${results_count} results for ${batch_count} queries (index mismatch)" >&2
   fi
 

--- a/skills/comprehensive-review/HELP.md
+++ b/skills/comprehensive-review/HELP.md
@@ -10,7 +10,7 @@ Flags
   --base <branch>    Compare against a different base branch (default: auto-detect or main)
   --quick            Fast mode: pr-summarizer + code-reviewer + triggered error/test agents.
                      Skips security, architecture, blind-hunter, edge-case-hunter, comment,
-                     and type analysis. ~75% cheaper.
+                     and type analysis. Roughly 60–80% cheaper depending on diff composition.
   --diagrams         Include Mermaid sequence diagrams in the summary (default: omitted;
                      always omitted in --quick)
   --security-only    Run security-reviewer + CVE check (on changed dep manifests) only

--- a/skills/comprehensive-review/HELP.md
+++ b/skills/comprehensive-review/HELP.md
@@ -13,7 +13,7 @@ Flags
                      and type analysis. ~75% cheaper.
   --diagrams         Include Mermaid sequence diagrams in the summary (default: omitted;
                      always omitted in --quick)
-  --security-only    Run security-reviewer only
+  --security-only    Run security-reviewer + CVE check (on changed dep manifests) only
   --summary-only     Run pr-summarizer only
 
   --create-pr        Create a PR using the summary (Block A) as the description
@@ -44,10 +44,12 @@ Agents — --quick mode
   Conditional:       silent-failure-hunter, pr-test-analyzer (if patterns match)
   Skipped:           all full-run-only + comment-analyzer, type-design-analyzer, issue-linker
 
-Deterministic checks (both full and --quick)
+Deterministic checks (all modes except --summary-only)
   dependency-check:  Queries OSV.dev for CVEs in changed dependency manifests.
-                     Triggers on: go.mod, package.json, requirements.txt, composer.json.
-                     No API key required. Network failures are non-blocking.
+                     Also runs in --security-only mode (CVE checks are security checks).
+                     Triggers on: go.mod, package.json, requirements*.txt, composer.json.
+                     Uses OSV /v1/querybatch for speed. No API key required.
+                     Network failures are non-blocking.
 
 claude-mem Integration (optional)
   When claude-mem is detected, the skill automatically stores a structured review

--- a/skills/comprehensive-review/HELP.md
+++ b/skills/comprehensive-review/HELP.md
@@ -23,6 +23,11 @@ Flags
   --no-post / --local  Skip all remote operations and issue-linker, display everything locally
   --pr <number>      Review an existing PR/MR by number (external review mode;
                      use --pr for all providers, including GitLab MRs)
+  --depth <tier>     Agent depth: normal (default) or deep.
+                     deep: blind-hunter and edge-case-hunter run on Opus 4.7,
+                     Opus agents use extended step-by-step reasoning, and a
+                     CVE reachability triage pass annotates which vulns are
+                     actually reachable in the diff.
   --provider <name>  Override git provider detection (github, gitlab, bitbucket)
   --no-mem           Disable claude-mem integration (auto-detected when available)
 

--- a/skills/comprehensive-review/SKILL.md
+++ b/skills/comprehensive-review/SKILL.md
@@ -86,6 +86,8 @@ Note: The `mcp__github-pat__*` tools in the `allowed-tools` frontmatter are only
 
 ### Provider Operations Reference
 
+> **Skip this entire section** if `--no-post` or `--local` was passed — no provider operations will fire in that mode.
+
 The following operations are referenced by name throughout Phases 0, 4, and 4b. Use the command corresponding to the detected PROVIDER.
 
 #### OP: Fetch PR/MR metadata (returns JSON with number, title, base branch, head branch, state)
@@ -183,9 +185,12 @@ The following operations are referenced by name throughout Phases 0, 4, and 4b. 
      ```
      Omit empty categories. Binary/generated files go under **Other**.
 
-5. **Read project context** — if CLAUDE.md exists in the repo root, extract a condensed
-   project-context block (~500 tokens max). Also check subdirectories of changed files.
-   If none exists: "No project-specific context available."
+5. **Read project context and prior review history concurrently** — run steps 5a and 5b in parallel (single tool-call batch):
+
+5a. **Read project context** — if CLAUDE.md exists in the repo root, extract a condensed
+   project-context block (~500 tokens max). Also check up to 5 distinct ancestor directories
+   of changed files for a CLAUDE.md (stop at repo root); concatenate matches up to the
+   ~500-token cap. If none exists: "No project-specific context available."
 
 5b. **Retrieve prior review history** (skip if MEM_AVAILABLE is false, or `--quick`, `--summary-only`, or `--security-only` mode is active):
    - Search for prior reviews of this project using the MCP tool:
@@ -246,7 +251,7 @@ Produce slices via `mktemp /tmp/cr-slice-<agent>-XXXXXXXX.txt` and `git diff <ba
 | (none) | All always-run + all triggered conditional agents (no diagrams unless `--diagrams` passed) + CVE check if manifest files changed |
 | `--quick` | pr-summarizer (no diagrams) + code-reviewer + triggered silent-failure-hunter and pr-test-analyzer + CVE check if manifest files changed |
 | `--no-post` / `--local` | Same as default but skips issue-linker; all Phase 4 GitHub operations suppressed |
-| `--security-only` | security-reviewer only |
+| `--security-only` | security-reviewer + CVE check (if manifest files changed) |
 | `--summary-only` | pr-summarizer only |
 
 **Model assignments** — always specify `model:` and `subagent_type:` explicitly when spawning agents via the Agent tool to prevent inheritance of the orchestrator's model and to avoid incorrect plugin-namespace inference:
@@ -287,18 +292,20 @@ Produce slices via `mktemp /tmp/cr-slice-<agent>-XXXXXXXX.txt` and `git diff <ba
 
 **Conditional agents — run in both full and `--quick` when triggered:**
 
-Detect triggers via grep on the temp diff file — do NOT read it into the conversation. Use `grep -qE` with a pattern file or a combined regex. **Important:** when the diff includes SKILL.md itself, exclude SKILL.md from the trigger check to avoid false positives (this grep command string contains the patterns it searches for):
+Detect triggers via boolean grep on the aggregate diff file — do NOT read it into the conversation. Use `grep -qE` as a boolean gate. **Important:** when the diff includes SKILL.md itself, exclude SKILL.md from the trigger check to avoid false positives (this grep command string contains the patterns it searches for):
 ```bash
-grep -l -E 'catch\b|if err|try \{|rescue\b|Result<|unwrap|\.error\(|\.expect\(|runCatching|guard\b|throws\b' "$DIFF_FILE"
+grep -qE 'catch\b|if err|try \{|rescue\b|Result<|unwrap|\.error\(|\.expect\(|runCatching|guard\b|throws\b' "$DIFF_FILE"
 ```
 
-- **silent-failure-hunter** (subagent_type: `pr-review-toolkit:silent-failure-hunter`, model: sonnet) — trigger: error handling patterns in **non-SKILL.md files** (`catch`, `if err`, `try {`, `rescue`, `Result<`, `unwrap`, etc.). When SKILL.md is the only file in the diff matching these patterns, do NOT trigger — the match is a false positive from the grep command definition above. Pass only matching files' diff.
-- **pr-test-analyzer** (subagent_type: `pr-review-toolkit:pr-test-analyzer`, model: sonnet) — trigger: test files (`*_test.go`, `test_*.py`, `*.test.ts`, `*.spec.ts`, `spec/`, `__tests__/`). Pass test files + source counterparts.
+The grep checks the aggregate diff as a boolean — if it matches anywhere, the agent is triggered and receives the **full diff** (not just matching files, because the diff is one concatenated file and per-file filtering would require more expensive hunk parsing). When SKILL.md is the only file in the diff matching these patterns, do NOT trigger — the match is a false positive from the grep command definition above.
+
+- **silent-failure-hunter** (subagent_type: `pr-review-toolkit:silent-failure-hunter`, model: sonnet) — trigger: error handling patterns in the diff (`catch`, `if err`, `try {`, `rescue`, `Result<`, `unwrap`, etc.). Pass the full diff when triggered.
+- **pr-test-analyzer** (subagent_type: `pr-review-toolkit:pr-test-analyzer`, model: sonnet) — trigger: test files in the diff (`*_test.go`, `test_*.py`, `*.test.ts`, `*.spec.ts`, `spec/`, `__tests__/`). Pass the full diff when triggered.
 
 **Conditional agents — full-run only** (skip in `--quick` and when not triggered):
 
-- **comment-analyzer** (subagent_type: `pr-review-toolkit:comment-analyzer`, model: sonnet) — trigger: comment lines (`//`, `#`, `/*`, `"""`, `'''`). Pass matching files' diff.
-- **type-design-analyzer** (subagent_type: `pr-review-toolkit:type-design-analyzer`, model: sonnet) — trigger: type definitions (`type ... struct`, `interface `, `class `, `enum `). Pass matching files' diff.
+- **comment-analyzer** (subagent_type: `pr-review-toolkit:comment-analyzer`, model: sonnet) — trigger: comment lines (`//`, `#`, `/*`, `"""`, `'''`) present in the diff. Pass the full diff when triggered.
+- **type-design-analyzer** (subagent_type: `pr-review-toolkit:type-design-analyzer`, model: sonnet) — trigger: type definitions (`type ... struct`, `interface `, `class `, `enum `) in the diff. Pass the full diff when triggered.
 - **issue-linker** (subagent_type: `issue-linker`, model: haiku) — pass commit log, branch name, manifest, repo slug, and PROVIDER value. Skip in `--quick`, `--pr`, and `--no-post`/`--local` modes. Also skipped when PROVIDER is not `github` (agent returns NONE for non-GitHub providers).
 
 Track skipped agents and reasons for Phase 5. Launch all applicable agents simultaneously.
@@ -307,7 +314,7 @@ Track skipped agents and reasons for Phase 5. Launch all applicable agents simul
 
 Run after all Phase 1 agents are launched (they run in parallel; this runs in the foreground while awaiting agent results).
 
-**CVE / dependency vulnerability check** — run when `MANIFEST_FILES` is non-empty (skip if `--summary-only` or `--security-only` mode; run in all other modes including `--quick`):
+**CVE / dependency vulnerability check** — run when `MANIFEST_FILES` is non-empty (skip only if `--summary-only` mode; run in all other modes including `--quick` and `--security-only`):
 
 ```bash
 CVE_SCRIPT="${CLAUDE_DIR:-$HOME/.claude}/scripts/run-cve-check.sh"
@@ -342,18 +349,19 @@ Wait for all agents. Check each output:
 
 | Agent | Their Scale | Maps To |
 |-------|-------------|---------|
-| code-reviewer | confidence [91,100] / [80,90] / [0,79] | Critical / High / Medium |
+| code-reviewer | confidence [91,100] / [80,90] / [60,79] / [0,59] | Critical / High / Medium / Low |
 | silent-failure-hunter | CRITICAL/HIGH/MEDIUM | pass through |
 | comment-analyzer | Critical/High/Medium/Low | pass through |
 | pr-test-analyzer | gap [8,10] / [5,7] / [3,4] / [1,2] | Critical / High / Medium / Low |
 | type-design-analyzer | rating [1,2] / [3,5] / [6,10] | High / Medium / Low |
 | architecture-reviewer, security-reviewer | Critical/High/Medium | pass through (Medium+ only) |
 | blind-hunter, edge-case-hunter | Critical/High/Medium/Low | pass through |
-| dependency-check | Critical/High/Medium/Low | pass through (identity mapping) |
+| dependency-check (parsed CVSS) | Critical/High/Medium/Low | pass through (identity mapping) |
+| dependency-check (CVSS unparsed / v4 / v2) | High | maps to High (conservative) |
 
 Also merge CVE findings from Phase 1b: if `CVE_JSON` is non-empty, add its entries to the normalized findings list before deduplication.
 
-**Deduplicate:** same `file:line` from two agents → keep highest severity, note "(also flagged by [agent2])". When a `dependency-check` finding and an LLM agent finding share the same `file:line`, prefer the `dependency-check` entry (it carries the authoritative CVE/GHSA ID) and append "(also flagged by [agent])". Same file without line → deduplicate by file + category.
+**Deduplicate:** same `file:line` from two agents → keep highest severity, note "(also flagged by [agent2])". When a `dependency-check` finding and an LLM agent finding share the same `file:line`, prefer the `dependency-check` entry (it carries the authoritative CVE/GHSA ID) and append "(also flagged by [agent])". Same file without line → deduplicate by file + category (category = the bracketed label at the start of each finding, e.g. `[secrets]`, `[injection]`, `[empty-collection]`, or `dependency-check` for CVE findings; normalize to a lowercased token before comparing).
 
 **Collect as structured data:** `{ severity, agent, file, line, finding, remediation }` per finding. Used for Block B rendering and Phase 4b inline comments.
 

--- a/skills/comprehensive-review/SKILL.md
+++ b/skills/comprehensive-review/SKILL.md
@@ -170,7 +170,7 @@ The following operations are referenced by name throughout Phases 0, 4, and 4b. 
 4. **Build the file manifest** from `git diff --stat <base>...HEAD -- ':!*lock.json' ':!*lock.yaml' ':!*.lock' ':!*.sum' ':!vendor/*' ':!node_modules/*'`:
    Lockfiles, vendor directories, and checksum files are excluded — the full DIFF_FILE still includes them.
    - Detect languages from extensions; categorize files as **Source**, **Tests**, **Config**, **Docs**, or **Dependency**
-   - Also collect `MANIFEST_FILES` — the subset of changed files named `go.mod`, `package.json`, `requirements.txt`, or `composer.json`. Use `git diff --name-only <base>...HEAD` (no exclusions) and filter by basename. Store as a newline-separated list for Phase 1b.
+   - Also collect `MANIFEST_FILES` — the subset of changed files named `go.mod`, `package.json`, `requirements*.txt` (any requirements file), or `composer.json`. Use `git diff --name-only <base>...HEAD` (no exclusions) and filter by basename. Store as a newline-separated list for Phase 1b.
    - Format:
      ```
      BASE: <base>  |  LANGUAGES: Go, TypeScript  |  FILES: <N>  |  LINES: +<added>/-<removed>
@@ -269,7 +269,7 @@ Produce slices via `mktemp /tmp/cr-slice-<agent>-XXXXXXXX.txt` and `git diff <ba
 **Always-run agents** (unless `--security-only` or `--summary-only` limits scope):
 
 - **pr-summarizer** (subagent_type: `pr-summarizer`, model: sonnet) — pass manifest, commit log, project context. Small diffs: also full diff inline.
-  Unless `--diagrams` is passed (and not `--quick`): add "Omit the Sequence Diagrams section entirely."
+  If `--diagrams` was passed (and not `--quick`): include `DIAGRAMS=true` in the task description. Otherwise: include `DIAGRAMS=false`.
 - **code-reviewer** (subagent_type: `pr-review-toolkit:code-reviewer`, model: sonnet) — always pass the full diff.
 
 **Full-run-only agents** (skipped with `--quick`):

--- a/skills/comprehensive-review/SKILL.md
+++ b/skills/comprehensive-review/SKILL.md
@@ -42,6 +42,7 @@ Supported flags:
 - `--no-post` / `--local` — display everything locally, skip all remote operations
 - `--pr <number>` — review an existing PR/MR by number (external review mode)
 - `--provider <name>` — override auto-detected git provider (valid: `github`, `gitlab`, `bitbucket`)
+- `--depth <normal|deep>` — agent-depth promotion: `deep` runs blind-hunter and edge-case-hunter on Opus 4.7 (same as security-reviewer/architecture-reviewer), adds step-by-step extended thinking instructions to all Opus agents, and adds a CVE reachability triage pass when CVE findings are found. Default: `normal` (current behavior unchanged).
 - `--no-mem` — disable claude-mem integration even if claude-mem is detected
 - `--help` — show this usage
 
@@ -138,6 +139,7 @@ The following operations are referenced by name throughout Phases 0, 4, and 4b. 
    - Extract `--provider <name>` if present — passed to Provider Detection (valid: `github`, `gitlab`, `bitbucket`)
    - Note mode flags: `--quick`, `--diagrams`, `--security-only`, `--summary-only`, `--create-pr`,
      `--no-post`/`--local`, `--post-summary`, `--post-findings`, `--no-findings`, `--no-mem`
+   - Extract `--depth <normal|deep>` if present; default DEPTH=`normal`. If value is not one of `{normal, deep}`, report "Error: Invalid --depth value '<value>'. Valid values are: normal, deep." and stop.
    - **Flag conflict checks:**
      - If both `--post-findings` and `--no-findings` are present, report
        "Error: --post-findings and --no-findings are mutually exclusive." and stop.
@@ -254,22 +256,22 @@ Produce slices via `mktemp /tmp/cr-slice-<agent>-XXXXXXXX.txt` and `git diff <ba
 | `--security-only` | security-reviewer + CVE check (if manifest files changed) |
 | `--summary-only` | pr-summarizer only |
 
-**Model assignments** — always specify `model:` and `subagent_type:` explicitly when spawning agents via the Agent tool to prevent inheritance of the orchestrator's model and to avoid incorrect plugin-namespace inference:
+**Model assignments** — the table below is the source of truth. Always specify `model:` and `subagent_type:` explicitly when spawning agents via the Agent tool. If this table disagrees with an agent's frontmatter `model:` field, this table wins — the frontmatter is a standalone default for agents running outside this skill.
 
-| Agent | subagent_type | Model |
-|-------|--------------|-------|
-| pr-summarizer | `pr-summarizer` | sonnet |
-| code-reviewer | `pr-review-toolkit:code-reviewer` | sonnet |
-| architecture-reviewer | `architecture-reviewer` | opus |
-| security-reviewer | `security-reviewer` | opus |
-| blind-hunter | `blind-hunter` | sonnet |
-| edge-case-hunter | `edge-case-hunter` | sonnet |
-| silent-failure-hunter | `pr-review-toolkit:silent-failure-hunter` | sonnet |
-| pr-test-analyzer | `pr-review-toolkit:pr-test-analyzer` | sonnet |
-| comment-analyzer | `pr-review-toolkit:comment-analyzer` | sonnet |
-| type-design-analyzer | `pr-review-toolkit:type-design-analyzer` | sonnet |
-| issue-linker | `issue-linker` | haiku |
-| dependency-check | `scripts/run-cve-check.sh` (script, not agent) | n/a |
+| Agent | subagent_type | Model (depth=normal) | Model (depth=deep) |
+|-------|--------------|----------------------|---------------------|
+| pr-summarizer | `pr-summarizer` | sonnet | sonnet |
+| code-reviewer | `pr-review-toolkit:code-reviewer` | sonnet | sonnet |
+| architecture-reviewer | `architecture-reviewer` | opus | opus |
+| security-reviewer | `security-reviewer` | opus | opus |
+| blind-hunter | `blind-hunter` | sonnet | **opus** |
+| edge-case-hunter | `edge-case-hunter` | sonnet | **opus** |
+| silent-failure-hunter | `pr-review-toolkit:silent-failure-hunter` | sonnet | sonnet |
+| pr-test-analyzer | `pr-review-toolkit:pr-test-analyzer` | sonnet | sonnet |
+| comment-analyzer | `pr-review-toolkit:comment-analyzer` | sonnet | sonnet |
+| type-design-analyzer | `pr-review-toolkit:type-design-analyzer` | sonnet | sonnet |
+| issue-linker | `issue-linker` | haiku | haiku |
+| dependency-check | `scripts/run-cve-check.sh` (script, not agent) | n/a | n/a |
 
 **Always-run agents** (unless `--security-only` or `--summary-only` limits scope):
 
@@ -281,13 +283,15 @@ Produce slices via `mktemp /tmp/cr-slice-<agent>-XXXXXXXX.txt` and `git diff <ba
 
 - **architecture-reviewer** (subagent_type: `architecture-reviewer`, model: opus) — pass manifest, commit log, project context. Small diffs: also full diff inline.
   If PRIOR_REVIEW_CONTEXT is non-empty, append it after project context with the heading "Prior review history (for pattern context):".
+  If `--depth deep`: also include `EXTENDED_THINKING=true` in the task description.
 - **security-reviewer** (subagent_type: `security-reviewer`, model: opus) — pass manifest, commit log, detected languages, project context. Small diffs: also full diff inline.
   If PRIOR_REVIEW_CONTEXT is non-empty, append it after project context with the heading "Prior review history (for pattern context):".
-- **blind-hunter** (subagent_type: `blind-hunter`, model: sonnet) — **ZERO CONTEXT CONSTRAINT: pass ONLY the diff. No manifest, no project context, no commit log.**
+  If `--depth deep`: also include `EXTENDED_THINKING=true` in the task description.
+- **blind-hunter** (subagent_type: `blind-hunter`, model: sonnet if depth=normal or **opus** if depth=deep) — **ZERO CONTEXT CONSTRAINT: pass ONLY the diff. No manifest, no project context, no commit log.**
   Small diffs: full diff inline only.
   Medium/large (non-`--pr`): base branch name + plain file list from `git diff --name-only` (NOT the categorized manifest). Agent reads files via `git diff <base>...HEAD -- <file>`.
   Medium/large (`--pr` mode): `BLIND_DIFF_FILE=$(mktemp /tmp/cr-diff-blind-XXXXXXXX.txt) && git -C "$WORKTREE_PATH" diff <base>...HEAD > "$BLIND_DIFF_FILE"`, passes `$BLIND_DIFF_FILE` inline (agent has no worktree knowledge). Track for Phase 5 cleanup.
-- **edge-case-hunter** (subagent_type: `edge-case-hunter`, model: sonnet) — pass manifest, commit log, project context. Small diffs: also full diff inline.
+- **edge-case-hunter** (subagent_type: `edge-case-hunter`, model: sonnet if depth=normal or **opus** if depth=deep) — pass manifest, commit log, project context. Small diffs: also full diff inline.
   Has full codebase read access for surrounding context.
 
 **Conditional agents — run in both full and `--quick` when triggered:**
@@ -335,7 +339,19 @@ fi
 - Network failures are non-blocking: the script returns `[]` and logs to stderr.
 - `--no-post`/`--local` does **not** skip the CVE check; it only gates posting.
 
-After all Phase 1 agents complete and Phase 1b finishes, proceed to Phase 2.
+After all Phase 1 agents complete and Phase 1b finishes, run Phase 1c if applicable.
+
+### Phase 1c: CVE Reachability Triage (depth=deep only)
+
+**Skip Phase 1c** unless ALL of:
+- `--depth deep` was passed
+- `CVE_JSON` is non-empty (Phase 1b found vulnerabilities)
+
+When running: launch a single Opus agent to annotate each CVE finding with a `reachability` tag without dropping or modifying any findings. Pass `CVE_JSON` and the diff of the changed manifest files. Task description:
+
+> "You are a dependency security analyst. For each CVE finding in the JSON array below, determine whether the vulnerable package is actually reachable in this diff — i.e., is it used directly in changed code, or is it only a dev dependency, or is it a transitive dependency with no import visible in the diff? Return the same JSON array with one additional field per entry: `reachability` (string, one of: `reachable` | `dev-only` | `transitive-only` | `unknown`). Never drop findings. Never change any existing field. Only add the `reachability` field."
+
+Annotate findings in Phase 3 Block B with `(reachability: <value>)` when `reachability` is not `reachable` or `unknown`. On Opus agent failure, skip annotation silently and use the original CVE_JSON.
 
 ### Phase 2: Collect and Normalize Results
 

--- a/skills/comprehensive-review/SKILL.md
+++ b/skills/comprehensive-review/SKILL.md
@@ -322,7 +322,7 @@ else
 fi
 ```
 
-`CLAUDE_DIR` defaults to `$HOME/.claude` (the standard Claude Code config directory). The script reads the manifest file list from stdin, queries OSV.dev for each declared dependency, and emits a JSON array of `{ severity, agent, file, line, finding, remediation }` tuples — the same structure as Phase 2 agent findings — with `agent: "dependency-check"`.
+`CLAUDE_DIR` defaults to `$HOME/.claude` (the standard Claude Code config directory). The script reads the manifest file list from stdin, queries OSV.dev for each declared dependency via a single `/v1/querybatch` POST (not one call per package), and emits a JSON array of `{ severity, agent, file, line, finding, remediation }` tuples — the same structure as Phase 2 agent findings — with `agent: "dependency-check"`. Each finding text includes the CVSS score (e.g., `[CVSS 9.8]`) or version prefix (e.g., `[CVSS:4.0]`) when the score cannot be computed. CVSS v4.0 and v2 vectors map to High conservatively rather than silently defaulting to Medium.
 
 - Capture `CVE_JSON` from stdout; on any non-zero exit, set to `[]` and emit a warning to stderr.
 - Network failures are non-blocking: the script returns `[]` and logs to stderr.

--- a/skills/comprehensive-review/SKILL.md
+++ b/skills/comprehensive-review/SKILL.md
@@ -31,9 +31,9 @@ Run a full CodeRabbit-style review of all changes on the current branch (or a sp
 
 Supported flags:
 - `--base <branch>` — compare against a different base branch (default: auto-detect upstream or `main`)
-- `--quick` — fast mode: pr-summarizer + code-reviewer + triggered error/test agents only; skips security, architecture, blind-hunter, edge-case-hunter, comment, and type analysis (~75% cheaper)
+- `--quick` — fast mode: pr-summarizer + code-reviewer + triggered error/test agents only; skips security, architecture, blind-hunter, edge-case-hunter, comment, and type analysis (roughly 60–80% cheaper depending on diff composition)
 - `--diagrams` — include Mermaid sequence diagrams in Block A (default: omitted; always omitted in `--quick`)
-- `--security-only` — run security-reviewer only
+- `--security-only` — run security-reviewer + CVE check (on changed dependency manifests) only
 - `--summary-only` — run pr-summarizer only
 - `--create-pr` — create a PR using Block A as the description (without this flag, no PR is created)
 - `--post-summary` — post Block A (informational summary) as a comment on an existing PR/MR
@@ -273,6 +273,15 @@ Produce slices via `mktemp /tmp/cr-slice-<agent>-XXXXXXXX.txt` and `git diff <ba
 | issue-linker | `issue-linker` | haiku | haiku |
 | dependency-check | `scripts/run-cve-check.sh` (script, not agent) | n/a | n/a |
 
+**Agent task-description directive protocol** — Agents key off `KEY=value` strings embedded in their task description to enable optional behaviors. This is the authoritative registry:
+
+| Directive | Value | Consumed by | Default when absent |
+|-----------|-------|-------------|---------------------|
+| `DIAGRAMS` | `true` / `false` | pr-summarizer | `false` (omit diagrams) |
+| `EXTENDED_THINKING` | `true` | architecture-reviewer, security-reviewer | not set (standard reasoning) |
+
+Rules: include directives as `KEY=value` on their own line at the start of the task description. Agents must ignore unrecognized directives. When adding a new directive, update this table.
+
 **Always-run agents** (unless `--security-only` or `--summary-only` limits scope):
 
 - **pr-summarizer** (subagent_type: `pr-summarizer`, model: sonnet) — pass manifest, commit log, project context. Small diffs: also full diff inline.
@@ -347,11 +356,13 @@ After all Phase 1 agents complete and Phase 1b finishes, run Phase 1c if applica
 - `--depth deep` was passed
 - `CVE_JSON` is non-empty (Phase 1b found vulnerabilities)
 
-When running: launch a single Opus agent to annotate each CVE finding with a `reachability` tag without dropping or modifying any findings. Pass `CVE_JSON` and the diff of the changed manifest files. Task description:
+When running: launch a single Opus agent (subagent_type: `security-reviewer`, model: `opus`) to annotate each CVE finding with a `reachability` tag without dropping or modifying any findings. Pass `CVE_JSON` and the diff of the changed manifest files. Task description:
 
 > "You are a dependency security analyst. For each CVE finding in the JSON array below, determine whether the vulnerable package is actually reachable in this diff — i.e., is it used directly in changed code, or is it only a dev dependency, or is it a transitive dependency with no import visible in the diff? Return the same JSON array with one additional field per entry: `reachability` (string, one of: `reachable` | `dev-only` | `transitive-only` | `unknown`). Never drop findings. Never change any existing field. Only add the `reachability` field."
 
-Annotate findings in Phase 3 Block B with `(reachability: <value>)` when `reachability` is not `reachable` or `unknown`. On Opus agent failure, skip annotation silently and use the original CVE_JSON.
+**Output validation:** After the agent returns, verify: (a) the output is a valid JSON array, (b) its length equals the input `CVE_JSON` length, (c) no existing field (`severity`, `agent`, `file`, `line`, `finding`, `remediation`) was modified. Use `jq` to diff the fields. If any check fails, discard the annotated output and use the original `CVE_JSON` unchanged — log "WARNING: Phase 1c output failed validation; using unannotated CVE_JSON." On Opus agent failure, also fall back to original `CVE_JSON`.
+
+Annotate findings in Phase 3 Block B: prefix `reachable` findings with `[REACHABLE]` (the most actionable signal); suffix `dev-only` with `(dev dependency)` and `transitive-only` with `(transitive)`. Leave `unknown` unannotated. This ensures the most important signal — confirmed reachability — is the most visible.
 
 ### Phase 2: Collect and Normalize Results
 


### PR DESCRIPTION
## Summary

Five-phase improvement release for the `comprehensive-review` plugin (v1.3.0 → v1.4.0).

- **Phase 1 — Correctness fixes:** Eliminated NONE-vs-prose empty-state contradictions in 4 agents; made Sequence Diagrams opt-in in pr-summarizer (saves tokens on every non-`--diagrams` run); fixed security-reviewer fallback from `HEAD~1...HEAD` (wrong for multi-commit PRs) to `@{u}...HEAD || main || master`; added missing-input fallback for architecture-reviewer; fixed edge-case-hunter placeholder reuse (`<N>/<M>` → `<C>/<F>/<D>`); added Read cap for edge-case-hunter; extended go.mod parser to honor `replace` directives; broadened requirements.txt parser to accept `~=`, `>=`, `<=`, `===` and `requirements*.txt` glob.
- **Phase 2 — CVE check overhaul:** Replaced serial per-package OSV `/v1/query` calls with a single `/v1/querybatch` POST (~100× faster on large manifests); added CVSS v4.0 and v2 handling (previously silently downgraded v4 Criticals); changed null-score fallback from Medium → High (conservative); added CVSS score display in finding text; improved remediation for packages with no fixed version; fixed O(n²) findings merge to O(1).
- **Phase 3 — Orchestrator efficiency:** Parallelized Phase 0 I/O (CLAUDE.md read + claude-mem search); capped CLAUDE.md subdir scan at 5 dirs; fixed grep-trigger from misleading `grep -l` to boolean `grep -qE`; flipped `--security-only` to run CVE check (counterintuitive to exclude it); gated Provider Operations Reference (saves ~400 tokens per local run); added Low tier to code-reviewer normalization; added `dependency-check Unknown → High` conservative row; defined "category" for dedup.
- **Phase 4 — Opus 4.7 leverage:** Added `--depth normal|deep` flag; in `deep` mode, blind-hunter and edge-case-hunter run on Opus 4.7, Opus agents use extended step-by-step reasoning via `EXTENDED_THINKING=true`, and a new Phase 1c CVE reachability triage pass annotates each finding with `reachability: reachable|dev-only|transitive-only|unknown`. Default behavior is unchanged.
- **Phase 5 — Docs + version bump:** Updated README and CLAUDE.md to document all new features; refreshed cost claims; bumped version to 1.4.0.

## Test plan

- [ ] Docs-only PR without `--diagrams` → no "Sequence Diagrams" in pr-summarizer output
- [ ] Clean PR → all agents emit literal `NONE`, not prose alternatives
- [ ] Edge-case-hunter Pass 1 summary shows `<C>/<F>/<D>` (not reused `<N>/<M>`)
- [ ] `requirements-dev.txt` with `Django>=3.2` → CVE check triggered
- [ ] go.mod with `replace` directive → OSV queried for replacement package/version
- [ ] CVE check on 50+ package manifest → completes in <5s (baseline ~30s serial)
- [ ] CVSS v4.0 vector in OSV mock → severity does not downgrade to Medium
- [ ] Finding text includes `[CVSS X.Y: Severity]` annotation
- [ ] Package with no fixed version → remediation says "No fixed version published yet..."
- [ ] `/comprehensive-review --security-only` on PR with package.json → CVE findings appear
- [ ] `/comprehensive-review --depth deep` → transcript shows `model: opus` for blind-hunter and edge-case-hunter
- [ ] `/comprehensive-review` (no flags) → output byte-identical to pre-v1.4.0 (modulo fixes)
- [ ] `jq -r .version .claude-plugin/plugin.json` → `1.4.0`