### PR TITLE
chore: update ai-pr-review submodule to latest main

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -105,6 +105,7 @@ jobs:
           model-premium: ${{ vars.AI_REVIEW_MODEL_PREMIUM }}
           review-mode: ${{ contains(github.event.pull_request.labels.*.name, 'ai-review-full') && 'full' || 'quick' }}
           force-full-diff: ${{ contains(github.event.pull_request.labels.*.name, 'ai-review-rescan') && 'true' || 'false' }}
+          parallel: 'true'
 
   # Job 3: always attempt to remove the ai-review-rescan label.
   # Running unconditionally (on non-fork PRs) avoids the "Skipped" indicator


### PR DESCRIPTION
## Summary

Updates the `ai-pr-review` submodule from commit `05fb0ba` to `6279017`, picking up five upstream PRs that add language profiles (PHP, TypeScript, Python), introduce tiered parallel agent execution (reducing wall-clock review time from ~5–7 minutes to ~2 minutes), and make parallel execution the default. The companion workflow change adds `parallel: 'true'` to this repo's invocation of the action, explicitly opting in to the new fan-out execution model.

**Type:** config
**Effort:** 1/5 — Two-file change: a submodule pointer bump and a single-line workflow addition.

## Walkthrough

| File | Change | Summary |
|------|--------|---------|
| `.github/actions/ai-pr-review` | Modified | Submodule pointer advanced from `05fb0ba` to `6279017`, picking up parallel execution support, PHP/TypeScript/Python language profiles, and duplicate-summary comment cleanup |
| `.github/workflows/ai-pr-review.yml` | Modified | Added `parallel: 'true'` input to opt in to tiered fan-out agent execution |