### PR TITLE
chore: update ai-pr-review submodule to 2f558d5 and sync workflow improvements

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -2,6 +2,9 @@ name: AI PR Review
 
 on:
   pull_request:
+    # ready_for_review fires when a draft PR is converted to ready. reopened is
+    # intentionally omitted — use the ai-review-rescan label to re-trigger on a
+    # reopened or otherwise stale PR.
     types: [opened, synchronize, ready_for_review, labeled]
 
 # Fork PRs cannot access secrets anyway; per-job guards below prevent
@@ -21,6 +24,11 @@ jobs:
   # submodule) using the PAT. Credentials are scrubbed from .git/config
   # before uploading the workspace artifact so the PAT does not travel
   # to the review job.
+  #
+  # Skipped for: fork PRs (no secret access anyway), draft PRs, bot actors
+  # (dependabot, renovate), PRs with skip-ai-review label, and label events
+  # that are not the two review-triggering labels. The review job propagates
+  # these skips via needs: prepare — it does not re-enumerate the conditions.
   prepare:
     runs-on: ubuntu-latest
     if: >-
@@ -79,10 +87,16 @@ jobs:
   # Job 2: run the composite action against the downloaded workspace.
   # This job does NOT run actions/checkout with the PAT, so the repo-scoped
   # PAT is never in its git config or accessible to the composite action.
+  # The prepare guard conditions are enforced by transitivity: when prepare
+  # is skipped (draft, bot, skip-ai-review, irrelevant label), needs.prepare.result
+  # is 'skipped', the if condition below is false, and this job is also skipped
+  # without attempting the artifact download.
   review:
     needs: prepare
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      needs.prepare.result == 'success' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Download workspace
         uses: actions/download-artifact@v8
@@ -101,7 +115,7 @@ jobs:
         with:
           api-key: ${{ secrets.AI_REVIEW_API_KEY }}
           provider: ${{ vars.AI_REVIEW_PROVIDER || 'anthropic' }}
-          base-url: ${{ vars.AI_REVIEW_BASE_URL || '' }}
+          base-url: ${{ vars.AI_REVIEW_BASE_URL }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ github.base_ref }}
           head-sha: ${{ github.event.pull_request.head.sha }}
@@ -110,14 +124,20 @@ jobs:
           model-premium: ${{ vars.AI_REVIEW_MODEL_PREMIUM }}
           review-mode: ${{ contains(github.event.pull_request.labels.*.name, 'ai-review-full') && 'full' || 'quick' }}
           force-full-diff: ${{ contains(github.event.pull_request.labels.*.name, 'ai-review-rescan') && 'true' || 'false' }}
+          # parallel defaults to true in the action since v71; no override needed
 
   # Job 3: always attempt to remove the ai-review-rescan label.
-  # needs: [prepare, review] with if: always() ensures this runs even when
-  # the review job is cancelled (e.g. by the concurrency rule on a new push)
-  # and when prepare is skipped (e.g. fork PRs or draft PRs). The gh api
-  # DELETE call returns 404 when the label is absent; || true swallows it.
-  # Excluded for skip-ai-review PRs to avoid stripping labels from intentionally
-  # bypassed reviews.
+  # Running on every non-fork, non-skip-ai-review PR event (even when prepare
+  # was skipped) avoids a "Skipped" indicator in the PR checks panel on normal
+  # pushes and ensures the label is cleaned up even when review is cancelled
+  # mid-run by the concurrency rule. The gh api DELETE returns 404 when the
+  # label is absent; || true swallows it so the step always succeeds.
+  #
+  # Intentionally does NOT replicate prepare's draft/bot/label-action guards:
+  # those are skips that suppress review, not reasons to leave a stale label.
+  # skip-ai-review is excluded to avoid stripping labels from intentionally
+  # bypassed PRs. Note: if ai-review-rescan is applied alongside skip-ai-review,
+  # the rescan label will persist until skip-ai-review is removed.
   cleanup-rescan-label:
     needs: [prepare, review]
     if: >-

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -2,14 +2,14 @@ name: AI PR Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, ready_for_review, labeled]
 
-# Only run on PRs from this repo — forks cannot access secrets anyway, and this
-# prevents untrusted fork branches from triggering jobs with write permissions.
+# Fork PRs cannot access secrets anyway; per-job guards below prevent
+# untrusted fork branches from triggering jobs with write permissions.
 # See: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections
 permissions:
-  pull-requests: write
   contents: read
+  pull-requests: write
   # issues: write is declared only on the cleanup-rescan-label job (least-privilege)
 
 concurrency:
@@ -17,38 +17,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Job 1: validate config and check out the repo (including the private submodule)
-  # using the PAT. Credentials are scrubbed before uploading the workspace artifact
-  # so the PAT does not travel to the review job via the artifact's .git/config.
+  # Job 1: validate config and check out the repo (including the private
+  # submodule) using the PAT. Credentials are scrubbed from .git/config
+  # before uploading the workspace artifact so the PAT does not travel
+  # to the review job.
   prepare:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft == false &&
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'renovate[bot]' &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-ai-review') &&
+      (github.event.action != 'labeled' ||
+       github.event.label.name == 'ai-review-full' ||
+       github.event.label.name == 'ai-review-rescan')
     steps:
-      # AI_REVIEW_API_KEY: required — the composite action has no sensible default.
-      # AI_PR_REVIEW_TOKEN: required — needed to clone the private submodule.
-      # AI_REVIEW_PROVIDER: validated defensively so the provider is explicit
-      #   rather than implicitly falling back to the action's 'anthropic' default.
-      # Other variables (AI_REVIEW_BASE_URL, AI_REVIEW_MODEL_STANDARD,
-      # AI_REVIEW_MODEL_PREMIUM) are intentionally optional — the composite action
-      # uses provider-appropriate defaults when they are empty.
+      # Fail fast with a clear error when required config is missing, rather
+      # than a cryptic git auth or API failure deeper in the pipeline.
+      # AI_REVIEW_PROVIDER is intentionally optional — the action defaults to 'anthropic'.
       - name: Validate required configuration
         env:
           AI_REVIEW_API_KEY: ${{ secrets.AI_REVIEW_API_KEY }}
           AI_PR_REVIEW_TOKEN: ${{ secrets.AI_PR_REVIEW_TOKEN }}
-          AI_REVIEW_PROVIDER: ${{ vars.AI_REVIEW_PROVIDER }}
         run: |
           missing=()
           [ -z "$AI_REVIEW_API_KEY" ] && missing+=("secret AI_REVIEW_API_KEY")
           [ -z "$AI_PR_REVIEW_TOKEN" ] && missing+=("secret AI_PR_REVIEW_TOKEN")
-          [ -z "$AI_REVIEW_PROVIDER" ] && missing+=("variable AI_REVIEW_PROVIDER")
           if [ ${#missing[@]} -gt 0 ]; then
             echo "ERROR: Missing required configuration: ${missing[*]}"
             echo "See the README for setup instructions."
             exit 1
           fi
 
-      # AI_PR_REVIEW_TOKEN requires: repo scope (to clone the private submodule).
-      # If the submodule becomes public, GITHUB_TOKEN is sufficient instead.
+      # AI_PR_REVIEW_TOKEN needs repo scope (or fine-grained read access to
+      # tag1consulting/ai-pr-review) to clone the private submodule.
+      # GITHUB_TOKEN cannot cross-repo clone private submodules.
       # This token is scoped to this job only; credentials are scrubbed before
       # the workspace is uploaded so the PAT does not reach the review job.
       - name: Checkout with submodules
@@ -58,6 +62,9 @@ jobs:
           token: ${{ secrets.AI_PR_REVIEW_TOKEN }}
           fetch-depth: 0
 
+      # actions/checkout writes the PAT into .git/config as a persistent
+      # credential. Scrubbing it before upload prevents the PAT from
+      # travelling to the review job via the artifact.
       - name: Scrub git credentials before artifact upload
         run: git config --unset-all http.https://github.com/.extraheader || true
 
@@ -69,10 +76,9 @@ jobs:
           include-hidden-files: true
           retention-days: 1
 
-  # Job 2: run the composite action against the checked-out workspace.
-  # The workspace artifact has credentials scrubbed; this job does not run
-  # actions/checkout with the PAT so the repo-scoped PAT is never in this
-  # job's git config or accessible to the composite action.
+  # Job 2: run the composite action against the downloaded workspace.
+  # This job does NOT run actions/checkout with the PAT, so the repo-scoped
+  # PAT is never in its git config or accessible to the composite action.
   review:
     needs: prepare
     runs-on: ubuntu-latest
@@ -85,9 +91,8 @@ jobs:
           path: .
 
       # actions/upload-artifact strips file permissions. Restore execute bits
-      # on the composite action's shell scripts. Git hooks are NOT made
-      # executable — they are not needed for the review and enabling them
-      # would allow arbitrary code execution via a malicious hook in the PR.
+      # on the composite action's shell scripts only — NOT on .git/hooks/*,
+      # which would allow arbitrary code execution via a malicious hook in the PR.
       - name: Restore executable bits
         run: find .github/actions/ai-pr-review -name "*.sh" -exec chmod +x {} +
 
@@ -95,8 +100,8 @@ jobs:
         uses: ./.github/actions/ai-pr-review
         with:
           api-key: ${{ secrets.AI_REVIEW_API_KEY }}
-          provider: ${{ vars.AI_REVIEW_PROVIDER }}
-          base-url: ${{ vars.AI_REVIEW_BASE_URL }}
+          provider: ${{ vars.AI_REVIEW_PROVIDER || 'anthropic' }}
+          base-url: ${{ vars.AI_REVIEW_BASE_URL || '' }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           base-ref: ${{ github.base_ref }}
           head-sha: ${{ github.event.pull_request.head.sha }}
@@ -105,19 +110,23 @@ jobs:
           model-premium: ${{ vars.AI_REVIEW_MODEL_PREMIUM }}
           review-mode: ${{ contains(github.event.pull_request.labels.*.name, 'ai-review-full') && 'full' || 'quick' }}
           force-full-diff: ${{ contains(github.event.pull_request.labels.*.name, 'ai-review-rescan') && 'true' || 'false' }}
-          parallel: 'true'
 
   # Job 3: always attempt to remove the ai-review-rescan label.
-  # Running unconditionally (on non-fork PRs) avoids the "Skipped" indicator
-  # in the PR checks panel on normal pushes. The gh api call returns 404 when
-  # the label is absent; || true swallows it so the step always succeeds.
-  # needs: [prepare, review] with if: always() ensures this runs even when the
-  # review job is cancelled (e.g. by the concurrency rule on a new push).
+  # needs: [prepare, review] with if: always() ensures this runs even when
+  # the review job is cancelled (e.g. by the concurrency rule on a new push)
+  # and when prepare is skipped (e.g. fork PRs or draft PRs). The gh api
+  # DELETE call returns 404 when the label is absent; || true swallows it.
+  # Excluded for skip-ai-review PRs to avoid stripping labels from intentionally
+  # bypassed reviews.
   cleanup-rescan-label:
     needs: [prepare, review]
-    if: always() && github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      always() &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-ai-review')
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
     steps:
       - name: Remove ai-review-rescan label


### PR DESCRIPTION
## Summary

This PR advances the `ai-pr-review` submodule from `6279017` to `2f558d5` (PR #77: accuracy, resilience, and test coverage improvements — transient retry hardening, dedup/filter pipeline fixes, new bats test coverage for `call_agent`, `retry_curl`, `parse_valid_lines`, and dedup/filter) and syncs `ai-pr-review.yml` with improvements from the upstream submodule documentation.

The `prepare` job gains a multi-condition guard that suppresses execution for draft PRs, bot actors (`dependabot[bot]`, `renovate[bot]`), and PRs carrying a `skip-ai-review` label. The `reopened` trigger is replaced with `ready_for_review` to align with the new draft-PR gate (use the `ai-review-rescan` label to re-trigger on a reopened PR). `AI_REVIEW_PROVIDER` is demoted from required to optional (the action defaults to `anthropic`), and `parallel: 'true'` is dropped since parallel execution is now the default since v71. The `cleanup-rescan-label` job gains a matching `skip-ai-review` guard and an explicit `contents: read` permission.

**Type:** chore
**Effort:** 2/5 — Confined to one YAML workflow file and a submodule pointer bump.

## Walkthrough

| File | Change | Summary |
|------|--------|---------|
| `.github/workflows/ai-pr-review.yml` | Modified | Replaced `reopened` trigger with `ready_for_review`; added multi-condition `if` guards for draft PRs, bots, and `skip-ai-review` label on `prepare`; added `needs.prepare.result == 'success'` guard to `review` to prevent artifact-download failure when `prepare` is skipped; made `AI_REVIEW_PROVIDER` optional; dropped explicit `parallel` input; added `contents: read` to cleanup job; updated and expanded inline comments |
| `.github/actions/ai-pr-review` | Modified | Submodule pointer advanced from `6279017` to `2f558d5` (PR #77: accuracy, resilience, and test coverage improvements) |

## Related Issues & PRs

| # | Title | Status | Relevance |
|---|-------|--------|-----------|
| #48 | chore: update ai-pr-review submodule to latest main | merged | Prior submodule update; this is the follow-up sync |
| #46 | chore: update ai-pr-review submodule to 05fb0ba | merged | Earlier submodule bump in the update chain |
| #35 | feat: add ai-pr-review GitHub Action via submodule | merged | Original integration; established the workflow foundation |