### PR TITLE
feat: TIER=tiny auto-branch, RELATED_FILES pointers, hardened CVE path discovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,10 +43,13 @@ The skill coordinates two groups of agents:
 
 The orchestrator uses a tiered approach to minimize token consumption:
 
-- **Small diffs (under 300 lines)**: Full diff passed inline to all agents — at this size, the tool-call overhead of selective reads exceeds the token cost of including the full diff.
-- **Medium/large diffs (300+ lines)**: Custom agents receive a structured **file manifest** (file list, categories, languages, line counts) and use selective `git diff <base>...HEAD -- <file>` reads. Toolkit agents (which we cannot modify) receive only the diff slices relevant to their specialty. Lockfiles, vendor directories, and checksum files are excluded from the manifest (but remain in DIFF_FILE).
+- **Tiny diffs (under 50 lines AND ≤3 files — TIER=tiny)**: Auto-selected; pr-summarizer routes to Haiku; architecture-reviewer and security-reviewer are skipped unless triggered by infra/CI paths or auth/credential/dep-manifest paths respectively; blind-hunter, edge-case-hunter, comment-analyzer, type-design-analyzer unconditionally skipped. PRIOR_REVIEW_CONTEXT and FILE_DIGEST are omitted — the diff is always passed inline. RELATED_FILES (see below) is still built and passed. Floor cost drops from ~$1 to ~$0.30.
+- **Small diffs (under 300 lines — TIER=small)**: Full diff passed inline to all agents — at this size, the tool-call overhead of selective reads exceeds the token cost of including the full diff.
+- **Medium/large diffs (300+ lines — TIER=medium)**: Custom agents receive a structured **file manifest** (file list, categories, languages, line counts) and use selective `git diff <base>...HEAD -- <file>` reads. Toolkit agents (which we cannot modify) receive only the diff slices relevant to their specialty. Lockfiles, vendor directories, and checksum files are excluded from the manifest (but remain in DIFF_FILE).
 
 The orchestrator also pre-reads CLAUDE.md and the commit log in Phase 0, passing condensed versions to agents so they don't fetch these independently. The orchestrator always specifies both `model:` and `subagent_type:` explicitly when spawning agents via the Agent tool — `model:` prevents subagents from inheriting the orchestrator's model, and `subagent_type:` prevents incorrect plugin-namespace inference.
+
+When the diff touches version-pin files (`.nvmrc`, `package.json`, `composer.json`, etc.) or infra/CI configs (Dockerfiles, `.github/workflows/`, etc.), the orchestrator builds a **RELATED_FILES** block — a list of adjacent files outside the diff that may have drifted (e.g., a Dockerfile still pinned to Node 22 when `.nvmrc` now requires 24). This is passed to architecture-reviewer and security-reviewer as an explicit `RELATED_FILES:` directive. CVE script (`run-cve-check.sh`) path is resolved via `$CLAUDE_PLUGIN_ROOT` first (plugin install), then `$CLAUDE_DIR`, then `$HOME/.claude`, then a known marketplace path — first executable match wins.
 
 ### Agent scope boundaries
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ Run from any git repository, on the branch you want to review:
 | Flag | Effect |
 |------|--------|
 | `--base <branch>` | Compare against a specific base branch (default: auto-detected upstream or `main`) |
-| `--quick` | Fast mode: pr-summarizer + code-reviewer + triggered error/test agents only. Skips security, architecture, blind-hunter, edge-case-hunter, comment, and type analysis. Roughly 60–80% cheaper depending on diff composition. |
+| `--quick` | Fast mode: pr-summarizer + code-reviewer + triggered error/test agents only. Skips security, architecture, blind-hunter, edge-case-hunter, comment, and type analysis. Roughly 60–80% cheaper depending on diff composition. When the diff is also tiny (<50 lines, ≤3 files), auto-selected TIER=tiny further demotes pr-summarizer to Haiku. No flag needed. |
+| *(auto)* TIER=tiny | Automatically applied when the diff is under 50 lines AND ≤3 files. Routes pr-summarizer to Haiku; skips blind-hunter, edge-case-hunter, comment-analyzer, type-design-analyzer unconditionally; skips architecture-reviewer and security-reviewer unless triggered by infra/CI paths or auth/credential/dep-manifest paths respectively. Roughly 60–70% cheaper than `--quick` on tiny diffs (~$1 → ~$0.30). |
 | `--diagrams` | Include Mermaid sequence diagrams in Block A. Default is omitted (saves hundreds of output tokens). Always omitted in `--quick`. |
 | `--security-only` | Run security-reviewer + CVE check on changed dependency manifests only |
 | `--depth <tier>` | Agent depth: `normal` (default) or `deep`. In `deep` mode, blind-hunter and edge-case-hunter run on the `opus` alias, Opus agents use extended step-by-step reasoning, and a CVE reachability triage pass annotates which vulnerabilities are reachable in the diff. |

--- a/skills/comprehensive-review/HELP.md
+++ b/skills/comprehensive-review/HELP.md
@@ -9,6 +9,11 @@ workflow coordination, not deep reasoning. Opus is reserved for the specialist a
 Opus costs ~$60–80 for a medium PR; Sonnet costs ~$30–45. Use --quick for ~60–80%
 cheaper reviews that skip the two Opus agents entirely.
 
+Tiny-PR tip: when the diff is under 50 lines and ≤3 files, the skill automatically
+selects TIER=tiny — pr-summarizer drops to Haiku, and Opus agents are skipped unless
+infra/security-path triggers promote them back. No flag needed; estimated floor cost
+drops from ~$1 to ~$0.30.
+
 Usage
   /comprehensive-review [flags]
 
@@ -58,6 +63,14 @@ Agents — --quick mode
   Always:            pr-summarizer (no diagrams), code-reviewer
   Conditional:       silent-failure-hunter, pr-test-analyzer (if patterns match)
   Skipped:           all full-run-only + comment-analyzer, type-design-analyzer, issue-linker
+
+Agents — TIER=tiny (auto, <50 lines AND ≤3 files)
+  Always:            pr-summarizer (Haiku), code-reviewer
+  Conditional:       silent-failure-hunter, pr-test-analyzer (if patterns match)
+                     architecture-reviewer (if infra/CI/cross-dir paths in diff)
+                     security-reviewer (if auth/credential/dep-manifest paths in diff)
+  Skipped:           blind-hunter, edge-case-hunter, comment-analyzer, type-design-analyzer,
+                     issue-linker (GitHub-only conditions still apply)
 
 Deterministic checks (all modes except --summary-only)
   dependency-check:  Queries OSV.dev for CVEs in changed dependency manifests.

--- a/skills/comprehensive-review/SKILL.md
+++ b/skills/comprehensive-review/SKILL.md
@@ -31,7 +31,7 @@ Run a full CodeRabbit-style review of all changes on the current branch (or a sp
 
 Supported flags:
 - `--base <branch>` — compare against a different base branch (default: auto-detect upstream or `main`)
-- `--quick` — fast mode: pr-summarizer + code-reviewer + triggered error/test agents only; skips security, architecture, blind-hunter, edge-case-hunter, comment, and type analysis (roughly 60–80% cheaper depending on diff composition)
+- `--quick` — fast mode: pr-summarizer + code-reviewer + triggered error/test agents only; skips security, architecture, blind-hunter, edge-case-hunter, comment, and type analysis (roughly 60–80% cheaper depending on diff composition). When the diff is also tiny (<50 lines, ≤3 files), the auto-selected TIER=tiny further demotes pr-summarizer to Haiku. No flag needed — tiny-tier is automatic.
 - `--diagrams` — include Mermaid sequence diagrams in Block A (default: omitted; always omitted in `--quick`)
 - `--security-only` — run security-reviewer + CVE check (on changed dependency manifests) only
 - `--summary-only` — run pr-summarizer only
@@ -57,6 +57,7 @@ Haiku is not recommended: Phase 2 deduplication and severity normalization acros
 - Opus orchestrator: $60–80 total (orchestrator alone ≈ $30 due to 100k+ cached tokens × 100+ turns at Opus cache-read rates)
 - Sonnet orchestrator: $30–45 total (orchestrator ≈ $6)
 - `--quick` mode: saves ~60–80% by skipping the two Opus agents
+- **Tiny-tier PRs (<50 lines, ≤3 files):** auto-selected TIER=tiny saves ~60–70% on top of `--quick` by routing pr-summarizer to Haiku and skipping/conditionally-promoting Opus agents. Floor cost drops from ~$1 to ~$0.30.
 
 ## Pre-flight Context
 
@@ -170,6 +171,64 @@ Note: The `mcp__github-pat__*` tools in the `allowed-tools` frontmatter are only
    git diff <base>...HEAD -- <file> | awk '/^@@/{found=1; count=0} found && count<20{print; count++}' 2>/dev/null
    ```
    Combine into a `FILE_DIGEST` block (~1 line of stat + ≤20 diff lines per file). Cap the entire FILE_DIGEST at 200 lines total — if more files exist, include stats for all but limit hunks to the top N by lines-changed. Pass FILE_DIGEST as part of the task description for architecture-reviewer and security-reviewer in Phase 1.
+   **TIER=tiny:** skip FILE_DIGEST entirely (saves prompt tokens; the diff is always inlined at tiny tier).
+
+   **Build RELATED_FILES** — a pointer list of adjacent files *outside* the diff that may drift when the diff touches version pins, infra, or CI configs. This surfaces cross-file skew like "Dockerfile pins Node 22 but `.nvmrc` now requires 24." Run immediately after FILE_DIGEST (skip if TIER=medium and diff has no version-pin/infra/CI paths):
+   ```bash
+   RELATED_FILES=""
+   declare -a POINTER_GLOBS=()
+   DIFF_PATHS=$(git diff --name-only <base>...HEAD)  # in --pr mode: git -C "$WORKTREE_PATH" diff ...
+
+   # Language/runtime version pins → infra that consumes them
+   if echo "$DIFF_PATHS" | grep -qE '(^|/)(\.nvmrc|package\.json|\.node-version)$'; then
+     POINTER_GLOBS+=('lagoon/*.dockerfile' 'lagoon/Dockerfile*' 'Dockerfile*'
+                     '.github/workflows/*.yml' '.github/workflows/*.yaml'
+                     '.gitlab-ci.yml' 'bitbucket-pipelines.yml'
+                     'docker-compose*.yml' 'docker-compose*.yaml' '.ddev/config.yaml')
+   fi
+   if echo "$DIFF_PATHS" | grep -qE '(^|/)(composer\.json|pyproject\.toml|go\.mod|\.ruby-version|Gemfile)$'; then
+     POINTER_GLOBS+=('lagoon/*.dockerfile' 'lagoon/Dockerfile*' 'Dockerfile*'
+                     '.github/workflows/*.yml' '.gitlab-ci.yml' 'bitbucket-pipelines.yml')
+   fi
+
+   # Infra changes → language pins they should match
+   if echo "$DIFF_PATHS" | grep -qE '(^|/)Dockerfile|(^|/)lagoon/|(^|/)docker-compose'; then
+     POINTER_GLOBS+=('.nvmrc' '.node-version' 'package.json' 'composer.json'
+                     'pyproject.toml' 'go.mod' '.ruby-version' 'Gemfile'
+                     '.github/workflows/*.yml' '.gitlab-ci.yml' 'bitbucket-pipelines.yml')
+   fi
+
+   # CI changes → Dockerfiles + language pins
+   if echo "$DIFF_PATHS" | grep -qE '(^|/)\.github/workflows/|(^|/)\.gitlab-ci\.yml|(^|/)bitbucket-pipelines\.yml'; then
+     POINTER_GLOBS+=('Dockerfile*' 'lagoon/*.dockerfile' 'lagoon/Dockerfile*'
+                     '.nvmrc' '.node-version' 'package.json' 'composer.json'
+                     'pyproject.toml' 'go.mod' '.ruby-version')
+   fi
+
+   if [[ ${#POINTER_GLOBS[@]} -gt 0 ]]; then
+     ALL_REPO_FILES=$(git ls-tree -r HEAD --name-only)  # in --pr mode: git -C "$WORKTREE_PATH" ls-tree ...
+     DIFF_SET=$(echo "$DIFF_PATHS" | sort -u)
+     MATCHES=""
+     for pat in "${POINTER_GLOBS[@]}"; do
+       # Convert glob to grep-regex: * → [^/]*, escape dots
+       re=$(echo "$pat" | sed 's/\./\\./g; s/\*/[^\/]*/g')
+       MATCHES+=$(echo "$ALL_REPO_FILES" | grep -E "(^|/)${re}$" || true)
+       MATCHES+=$'\n'
+     done
+     # Keep files that exist in repo, are NOT in the diff, dedupe, cap at 15
+     RELATED_FILES=$(echo "$MATCHES" | sort -u | grep -vxFf <(echo "$DIFF_SET") \
+                     | grep -v '^$' | head -n 15)
+   fi
+   ```
+   When `RELATED_FILES` is non-empty, pass this block in the task description for architecture-reviewer and security-reviewer:
+   ```
+   RELATED_FILES:
+   Consider reviewing these adjacent files for version/config drift (not in the diff):
+     - <file1>
+     - <file2>
+     ...
+   ```
+   If `RELATED_FILES` is empty, omit the section entirely — do not add noise. RELATED_FILES is built and passed at all tiers, including TIER=tiny (it is the primary discovery mechanism for Opus agents promoted by an infra trigger at tiny tier).
 
 5. **Read project context and prior review history concurrently** — run steps 5a and 5b in parallel (single tool-call batch):
 
@@ -202,10 +261,54 @@ Note: The `mcp__github-pat__*` tools in the `allowed-tools` frontmatter are only
    pre-flight for own-branch; captured fresh for `--pr` mode). Passed to agents so they
    don't fetch independently.
 
-7. **Determine diff size tier** from the manifest's total changed lines (lockfiles excluded):
-   - **Small** (under 300 lines): full diff passed inline to agents
-   - **Medium/Large** (300+ lines): agents receive file manifest and read selectively
-   - Default to **Medium/Large** if line count is ambiguous
+7. **Determine diff size tier** from the manifest's total changed lines and file count (lockfiles/vendor excluded):
+
+   First, write the aggregate diff to a temp file — used by tier triggers and Phase 1 conditional agents:
+   ```bash
+   DIFF_FILE=$(mktemp /tmp/cr-diff-XXXXXXXX.txt)
+   git diff <base>...HEAD > "$DIFF_FILE"   # in --pr mode: git -C "$WORKTREE_PATH" diff ...
+   ```
+   Track DIFF_FILE for Phase 5 cleanup.
+
+   Then compute:
+   - `LINES_CHANGED` — total added+removed lines from the manifest stat (lockfiles already excluded)
+   - `FILES_CHANGED` — count of non-lockfile/vendor changed files from the manifest
+
+   Set **TIER** using both counts:
+   - **TIER=tiny**: `LINES_CHANGED < 50` AND `FILES_CHANGED <= 3`
+   - **TIER=small**: `LINES_CHANGED < 300` (and not tiny)
+   - **TIER=medium**: `LINES_CHANGED >= 300` (or if either count is ambiguous, default here)
+
+   The two-count gate prevents a 2-line change across 4 unrelated directories from being misclassified as tiny.
+
+   **TIER=tiny context reduction** — apply immediately before agent launch:
+   - Skip PRIOR_REVIEW_CONTEXT fetch (step 5b short-circuits — treat as if already empty).
+   - Do not build FILE_DIGEST (step 4 second half — skip the per-file digest portion).
+   - Commit log is passed only to pr-summarizer; all other agents get diff + PR title only.
+   - RELATED_FILES (step 4 tail) is still built and passed when non-empty — it is the primary signal for version-pin drift at tiny tier.
+
+   **TIER=tiny promotion triggers** — evaluate once via boolean grep on `$DIFF_FILE`:
+   ```bash
+   # Security trigger: auth/credential/dependency paths
+   SECURITY_PROMOTED=false
+   if git diff --name-only <base>...HEAD | grep -qE '(auth|passwords?|routes?/|/api/|credentials?|token|secret)' \
+     || git diff --name-only <base>...HEAD | grep -qE '(^|/)(package\.json|go\.mod|composer\.json|requirements.*\.txt|pyproject\.toml|Gemfile|Pipfile|[Cc]argo\.toml)$' \
+     || git diff --name-only <base>...HEAD | grep -qE '(^|/)\.env' \
+     || git diff --name-only <base>...HEAD | grep -qE 'settings\.(py|ya?ml|json|toml)$'; then
+     SECURITY_PROMOTED=true
+   fi
+
+   # Architecture trigger: infra/CI files or cross-directory change
+   ARCH_PROMOTED=false
+   if git diff --name-only <base>...HEAD | grep -qE '(^|/)(Dockerfile|\.nvmrc|\.node-version|\.ddev/|\.github/workflows/|\.gitlab-ci\.yml|bitbucket-pipelines\.yml|lagoon/|helm/|k8s/|kubernetes/|terraform/|docker-compose)'; then
+     ARCH_PROMOTED=true
+   elif [[ $(git diff --name-only <base>...HEAD | awk -F/ '{print $1}' | sort -u | wc -l | tr -d ' ') -ge 2 ]]; then
+     ARCH_PROMOTED=true
+   fi
+   ```
+   In `--pr` mode, prefix all git commands above with `git -C "$WORKTREE_PATH"`.
+   These triggers only apply at TIER=tiny; at TIER=small or TIER=medium they are ignored.
+   Surface both flags in Phase 5 metadata (e.g., `TIER=tiny — architecture-reviewer promoted by infra trigger`).
 
 8. Determine which agents to run (see Phase 1).
 
@@ -213,9 +316,9 @@ Note: The `mcp__github-pat__*` tools in the `allowed-tools` frontmatter are only
 
 #### Context Passing
 
-**Do not display raw diffs to the user.** Write diffs to temp files via `mktemp /tmp/cr-diff-XXXXXXXX.txt`, then Read them. Track all temp files for Phase 5 cleanup.
+**Do not display raw diffs to the user.** Write diffs to temp files (tracked for Phase 5 cleanup). `$DIFF_FILE` was already written in Phase 0 step 7; use it here. Write any per-agent slice files via `mktemp /tmp/cr-slice-<agent>-XXXXXXXX.txt`.
 
-**Small diffs (under 300 lines):** Capture full diff once to a temp file. Pass inline to all agents.
+**Small diffs (under 300 lines, i.e., TIER=small or TIER=tiny):** Pass full diff inline to all agents that receive a diff.
 
 **Medium/large diffs (300+ lines):** Pass each agent: file manifest, base branch name, condensed project context, and commit log (where needed). Custom agents read files selectively via `git diff <base>...HEAD -- <file>`.
 
@@ -239,6 +342,7 @@ Produce slices via `mktemp /tmp/cr-slice-<agent>-XXXXXXXX.txt` and `git diff <ba
 | `--no-post` / `--local` | Same as default but skips issue-linker; all Phase 4 GitHub operations suppressed |
 | `--security-only` | security-reviewer + CVE check (if manifest files changed) |
 | `--summary-only` | pr-summarizer only |
+| `TIER=tiny` (auto, <50 lines AND ≤3 files) | pr-summarizer (Haiku) + code-reviewer + CVE check if manifest files changed + triggered silent-failure-hunter / pr-test-analyzer; architecture-reviewer and security-reviewer run only when promoted by their respective triggers (infra/cross-dir vs auth/dep paths); blind-hunter, edge-case-hunter, comment-analyzer, type-design-analyzer unconditionally skipped. When `--quick` is also active, stricter rule wins (TIER=tiny further demotes pr-summarizer to Haiku). `--security-only` overrides TIER=tiny — security-reviewer always runs. `--depth deep` promotes any trigger-activated Opus agents to opus+extended-thinking but does NOT un-skip unconditionally-skipped agents. |
 
 **Model assignments** — the table below is the source of truth. Always specify `model:` and `subagent_type:` explicitly when spawning agents via the Agent tool. If this table disagrees with an agent's frontmatter `model:` field, this table wins — the frontmatter is a standalone default for agents running outside this skill.
 
@@ -257,12 +361,29 @@ Produce slices via `mktemp /tmp/cr-slice-<agent>-XXXXXXXX.txt` and `git diff <ba
 | issue-linker | `issue-linker` | haiku | haiku |
 | dependency-check | `scripts/run-cve-check.sh` (script, not agent) | n/a | n/a |
 
+**TIER=tiny model overrides** — when TIER=tiny was computed in Phase 0 step 7, apply these overrides on top of the model table. Overrides only apply at TIER=tiny; at TIER=small/medium the model table governs unchanged.
+
+| Agent | TIER=tiny override |
+|-------|-------------------|
+| pr-summarizer | haiku (instead of sonnet); drop commit log and project context — pass diff + PR title only |
+| architecture-reviewer | **skip** unless ARCH_PROMOTED=true; if promoted, run at opus (or opus+extended-thinking if depth=deep), pass diff inline + RELATED_FILES only (no FILE_DIGEST, no commit log, no project context) |
+| security-reviewer | **skip** unless SECURITY_PROMOTED=true; if promoted, run at opus (or opus+extended-thinking if depth=deep), pass diff inline + RELATED_FILES only |
+| blind-hunter | **skip unconditionally** |
+| edge-case-hunter | **skip unconditionally** |
+| comment-analyzer | **skip** |
+| type-design-analyzer | **skip** |
+| code-reviewer | unchanged (always pass full diff) |
+| silent-failure-hunter | unchanged (runs on content trigger) |
+| pr-test-analyzer | unchanged (runs on content trigger) |
+| issue-linker | unchanged (haiku, GitHub-only conditions unchanged) |
+
 **Agent task-description directive protocol** — Agents key off `KEY=value` strings embedded in their task description to enable optional behaviors. This is the authoritative registry:
 
 | Directive | Value | Consumed by | Default when absent |
 |-----------|-------|-------------|---------------------|
 | `DIAGRAMS` | `true` / `false` | pr-summarizer | `false` (omit diagrams) |
 | `EXTENDED_THINKING` | `true` | architecture-reviewer, security-reviewer | not set (standard reasoning) |
+| `RELATED_FILES` | newline-separated file paths | architecture-reviewer, security-reviewer | unset (no pointer list) |
 
 Rules: include directives as `KEY=value` on their own line at the start of the task description. Agents must ignore unrecognized directives. When adding a new directive, update this table.
 
@@ -270,24 +391,31 @@ Rules: include directives as `KEY=value` on their own line at the start of the t
 
 - **pr-summarizer** (subagent_type: `pr-summarizer`, model: sonnet) — pass manifest, commit log, project context. Small diffs: also full diff inline.
   If `--diagrams` was passed (and not `--quick`): include `DIAGRAMS=true` in the task description. Otherwise: include `DIAGRAMS=false`.
+  **TIER=tiny:** use haiku instead of sonnet; pass only diff + PR title (drop manifest, commit log, project context).
 - **code-reviewer** (subagent_type: `pr-review-toolkit:code-reviewer`, model: sonnet) — always pass the full diff.
 
 **Full-run-only agents** (skipped with `--quick`):
 
 - **architecture-reviewer** (subagent_type: `architecture-reviewer`, model: opus) — pass manifest, FILE_DIGEST (from Phase 0 step 4), commit log, project context. Small diffs: also full diff inline.
   If PRIOR_REVIEW_CONTEXT is non-empty, append it after project context with the heading "Prior review history (for pattern context):".
+  If RELATED_FILES is non-empty, include it in the task description (see directive table above).
   If `--depth deep`: also include `EXTENDED_THINKING=true` in the task description.
   Always include in the task description: `"Tool budget: prefer batching parallel Read/Grep calls. Stop after 25 total tool calls or when you have enough evidence — do not re-read files you have already inspected."`
+  **TIER=tiny:** skip unless ARCH_PROMOTED=true. When promoted, pass diff inline + RELATED_FILES only — drop FILE_DIGEST, commit log, project context, and PRIOR_REVIEW_CONTEXT.
 - **security-reviewer** (subagent_type: `security-reviewer`, model: opus) — pass manifest, FILE_DIGEST (from Phase 0 step 4), commit log, detected languages, project context. Small diffs: also full diff inline.
   If PRIOR_REVIEW_CONTEXT is non-empty, append it after project context with the heading "Prior review history (for pattern context):".
+  If RELATED_FILES is non-empty, include it in the task description (see directive table above).
   If `--depth deep`: also include `EXTENDED_THINKING=true` in the task description.
   Always include in the task description: `"Tool budget: prefer batching parallel Bash/Read calls. Stop after 25 total tool calls or when you have enough evidence — do not re-read files you have already inspected."`
+  **TIER=tiny:** skip unless SECURITY_PROMOTED=true. When promoted, pass diff inline + RELATED_FILES only — drop FILE_DIGEST, commit log, project context, and PRIOR_REVIEW_CONTEXT.
 - **blind-hunter** (subagent_type: `blind-hunter`, model: sonnet if depth=normal or **opus** if depth=deep) — **ZERO CONTEXT CONSTRAINT: pass ONLY the diff. No manifest, no project context, no commit log.**
   Small diffs: full diff inline only.
   Medium/large (non-`--pr`): base branch name + plain file list from `git diff --name-only` (NOT the categorized manifest). Agent reads files via `git diff <base>...HEAD -- <file>`.
   Medium/large (`--pr` mode): `BLIND_DIFF_FILE=$(mktemp /tmp/cr-diff-blind-XXXXXXXX.txt) && git -C "$WORKTREE_PATH" diff <base>...HEAD > "$BLIND_DIFF_FILE"`, passes `$BLIND_DIFF_FILE` inline (agent has no worktree knowledge). Track for Phase 5 cleanup.
+  **TIER=tiny:** skip unconditionally. `--depth deep` does not override this skip.
 - **edge-case-hunter** (subagent_type: `edge-case-hunter`, model: sonnet if depth=normal or **opus** if depth=deep) — pass manifest, commit log, project context. Small diffs: also full diff inline.
   Has full codebase read access for surrounding context.
+  **TIER=tiny:** skip unconditionally. `--depth deep` does not override this skip.
 
 **Conditional agents — run in both full and `--quick` when triggered:**
 
@@ -304,7 +432,9 @@ The grep checks the aggregate diff as a boolean — if it matches anywhere, the 
 **Conditional agents — full-run only** (skip in `--quick` and when not triggered):
 
 - **comment-analyzer** (subagent_type: `pr-review-toolkit:comment-analyzer`, model: sonnet) — trigger: comment lines (`//`, `#`, `/*`, `"""`, `'''`) present in the diff. Pass the full diff when triggered.
+  **TIER=tiny:** skip.
 - **type-design-analyzer** (subagent_type: `pr-review-toolkit:type-design-analyzer`, model: sonnet) — trigger: type definitions (`type ... struct`, `interface `, `class `, `enum `) in the diff. Pass the full diff when triggered.
+  **TIER=tiny:** skip.
 - **issue-linker** (subagent_type: `issue-linker`, model: haiku) — pass commit log, branch name, manifest, repo slug, and PROVIDER value. Skip in `--quick`, `--pr`, and `--no-post`/`--local` modes. Also skipped when PROVIDER is not `github` (agent returns NONE for non-GitHub providers).
 
 Track skipped agents and reasons for Phase 5. Launch all applicable agents simultaneously.
@@ -316,19 +446,30 @@ Run after all Phase 1 agents are launched (they run in parallel; this runs in th
 **CVE / dependency vulnerability check** — run when `MANIFEST_FILES` is non-empty (skip only if `--summary-only` mode; run in all other modes including `--quick` and `--security-only`):
 
 ```bash
-CVE_SCRIPT="${CLAUDE_DIR:-$HOME/.claude}/scripts/run-cve-check.sh"
+# Resolve run-cve-check.sh — try each install location in priority order.
+# TODO(follow-up): relocate to skills/comprehensive-review/scripts/ for simpler plugin-relative resolution.
+CVE_SCRIPT=""
+for candidate in \
+  "${CLAUDE_PLUGIN_ROOT:-}/scripts/run-cve-check.sh" \
+  "${CLAUDE_PLUGIN_ROOT:-}/skills/comprehensive-review/scripts/run-cve-check.sh" \
+  "${CLAUDE_DIR:-}/scripts/run-cve-check.sh" \
+  "$HOME/.claude/scripts/run-cve-check.sh" \
+  "$HOME/.claude/plugins/marketplaces/tag1consulting/plugins/comprehensive-review/scripts/run-cve-check.sh"; do
+  [[ -n "$candidate" && -x "$candidate" ]] && { CVE_SCRIPT="$candidate"; break; }
+done
+
 CVE_JSON="[]"
-if [[ -x "$CVE_SCRIPT" ]]; then
+if [[ -n "$CVE_SCRIPT" ]]; then
   CVE_JSON=$(bash "$CVE_SCRIPT" <<<"$MANIFEST_FILES") || {
-    echo "WARNING: run-cve-check.sh failed; CVE findings will be skipped." >&2
+    echo "WARNING: run-cve-check.sh ($CVE_SCRIPT) failed; CVE findings will be skipped." >&2
     CVE_JSON="[]"
   }
 else
-  echo "WARNING: scripts/run-cve-check.sh not found; CVE check skipped. Re-run install to add it." >&2
+  echo "WARNING: run-cve-check.sh not found. Tried: \$CLAUDE_PLUGIN_ROOT/scripts, \$CLAUDE_DIR/scripts, ~/.claude/scripts, and the marketplace install path. CVE check skipped. Install via '/plugins install comprehensive-review@tag1consulting' or './install.sh --local'." >&2
 fi
 ```
 
-`CLAUDE_DIR` defaults to `$HOME/.claude` (the standard Claude Code config directory). The script reads the manifest file list from stdin, queries OSV.dev for each declared dependency via a single `/v1/querybatch` POST (not one call per package), and emits a JSON array of `{ severity, agent, file, line, finding, remediation }` tuples — the same structure as Phase 2 agent findings — with `agent: "dependency-check"`. Each finding text includes the CVSS score (e.g., `[CVSS 9.8]`) or version prefix (e.g., `[CVSS:4.0]`) when the score cannot be computed. CVSS v4.0 and v2 vectors map to High conservatively rather than silently defaulting to Medium.
+Path resolution order: `$CLAUDE_PLUGIN_ROOT` (set by the plugin harness when the skill runs as an installed plugin) → `$CLAUDE_PLUGIN_ROOT/skills/comprehensive-review/scripts/` → `$CLAUDE_DIR` → `$HOME/.claude` → known marketplace install path. First executable match wins. The script reads the manifest file list from stdin, queries OSV.dev for each declared dependency via a single `/v1/querybatch` POST (not one call per package), and emits a JSON array of `{ severity, agent, file, line, finding, remediation }` tuples — the same structure as Phase 2 agent findings — with `agent: "dependency-check"`. Each finding text includes the CVSS score (e.g., `[CVSS 9.8]`) or version prefix (e.g., `[CVSS:4.0]`) when the score cannot be computed. CVSS v4.0 and v2 vectors map to High conservatively rather than silently defaulting to Medium.
 
 - Capture `CVE_JSON` from stdout; on any non-zero exit, set to `[]` and emit a warning to stderr.
 - Network failures are non-blocking: the script returns `[]` and logs to stderr.
@@ -554,7 +695,9 @@ Note in terminal: "Review written to <path>"
 3. Review posted → "Review posted to ${PR_TERM} #<N>: <N> inline, <M> in body"
 4. Always display Block B (findings).
 5. Report skipped agents: "--quick mode skipped: ..." and "Skipped (no patterns): ..."
-6. Report Opus agent tool-call usage: "Agent tool calls: architecture-reviewer=<N> (budget 25), security-reviewer=<N> (budget 25)" — flag with ⚠ if either exceeds 25 so you can tighten the prompt over time.
+6. Report diff tier and Opus agent tool-call usage:
+   - `"Diff tier: <tiny|small|medium>  (<N> lines, <M> files)"` — if TIER=tiny, also show which agents were promoted or skipped, e.g.: `"TIER=tiny — architecture-reviewer: promoted (infra trigger) | security-reviewer: skipped | blind-hunter: skipped | edge-case-hunter: skipped"`
+   - `"Agent tool calls: architecture-reviewer=<N> (budget 25), security-reviewer=<N> (budget 25)"` — flag with ⚠ if either exceeds 25 so you can tighten the prompt over time. Omit any agent that was skipped.
 7. **Display a token utilization table** (always shown, even if no findings). **Always include both token counts AND the estimated cost — do not simplify to tools+cost only.** Include every agent that ran plus the orchestrator row as "orchestrator (this session)". Build the table from the agent task result metadata (tool-call counts are tracked per agent as each completes). Use these pricing constants: Opus input $15/M, Opus output $75/M, Opus cache_write $18.75/M, Opus cache_read $1.50/M; Sonnet input $3/M, Sonnet output $15/M, Sonnet cache_write $3.75/M, Sonnet cache_read $0.30/M. For the orchestrator row, use the actual tool-call counts from the session (tracked by TaskCreate/TaskUpdate overhead), and note that orchestrator cost is an estimate (exact figures require `/cost`):
    ```
    Token utilization:

--- a/skills/comprehensive-review/SKILL.md
+++ b/skills/comprehensive-review/SKILL.md
@@ -177,7 +177,8 @@ Note: The `mcp__github-pat__*` tools in the `allowed-tools` frontmatter are only
    ```bash
    RELATED_FILES=""
    declare -a POINTER_GLOBS=()
-   DIFF_PATHS=$(git diff --name-only <base>...HEAD)  # in --pr mode: git -C "$WORKTREE_PATH" diff ...
+   DIFF_PATHS=$(git diff --name-only <base>...HEAD 2>/dev/null) \
+     || { echo "WARNING: git diff --name-only failed; RELATED_FILES will be empty." >&2; DIFF_PATHS=""; }
 
    # Language/runtime version pins → infra that consumes them
    if echo "$DIFF_PATHS" | grep -qE '(^|/)(\.nvmrc|package\.json|\.node-version)$'; then
@@ -206,14 +207,20 @@ Note: The `mcp__github-pat__*` tools in the `allowed-tools` frontmatter are only
    fi
 
    if [[ ${#POINTER_GLOBS[@]} -gt 0 ]]; then
-     ALL_REPO_FILES=$(git ls-tree -r HEAD --name-only)  # in --pr mode: git -C "$WORKTREE_PATH" ls-tree ...
+     ALL_REPO_FILES=$(git ls-tree -r HEAD --name-only 2>/dev/null) \
+       || { echo "WARNING: git ls-tree failed; RELATED_FILES will be empty." >&2; ALL_REPO_FILES=""; }
      DIFF_SET=$(echo "$DIFF_PATHS" | sort -u)
      MATCHES=""
      for pat in "${POINTER_GLOBS[@]}"; do
        # Convert glob to grep-regex: * → [^/]*, escape dots
        re=$(echo "$pat" | sed 's/\./\\./g; s/\*/[^\/]*/g')
-       MATCHES+=$(echo "$ALL_REPO_FILES" | grep -E "(^|/)${re}$" || true)
-       MATCHES+=$'\n'
+       grep_out=$(echo "$ALL_REPO_FILES" | grep -E "(^|/)${re}$" 2>/dev/null); grep_rc=$?
+       if [[ $grep_rc -eq 0 ]]; then
+         MATCHES+="$grep_out"$'\n'
+       elif [[ $grep_rc -ge 2 ]]; then
+         echo "WARNING: grep regex error for pattern '$re' in RELATED_FILES build; skipping." >&2
+       fi
+       # grep_rc=1 (no match) is normal — skip silently
      done
      # Keep files that exist in repo, are NOT in the diff, dedupe, cap at 15
      RELATED_FILES=$(echo "$MATCHES" | sort -u | grep -vxFf <(echo "$DIFF_SET") \
@@ -287,26 +294,34 @@ Note: The `mcp__github-pat__*` tools in the `allowed-tools` frontmatter are only
    - Commit log is passed only to pr-summarizer; all other agents get diff + PR title only.
    - RELATED_FILES (step 4 tail) is still built and passed when non-empty — it is the primary signal for version-pin drift at tiny tier.
 
-   **TIER=tiny promotion triggers** — evaluate once via boolean grep on `$DIFF_FILE`:
+   **TIER=tiny promotion triggers** — fetch the changed-file list once, check the exit code, then run all greps against the cached output:
    ```bash
-   # Security trigger: auth/credential/dependency paths
-   SECURITY_PROMOTED=false
-   if git diff --name-only <base>...HEAD | grep -qE '(auth|passwords?|routes?/|/api/|credentials?|token|secret)' \
-     || git diff --name-only <base>...HEAD | grep -qE '(^|/)(package\.json|go\.mod|composer\.json|requirements.*\.txt|pyproject\.toml|Gemfile|Pipfile|[Cc]argo\.toml)$' \
-     || git diff --name-only <base>...HEAD | grep -qE '(^|/)\.env' \
-     || git diff --name-only <base>...HEAD | grep -qE 'settings\.(py|ya?ml|json|toml)$'; then
-     SECURITY_PROMOTED=true
-   fi
+   # Fetch once; default-promote if git fails so Opus agents aren't silently skipped.
+   TINY_DIFF_NAMES=$(git diff --name-only <base>...HEAD 2>/dev/null)
+   if [[ $? -ne 0 ]]; then
+     echo "WARNING: git diff --name-only failed during tiny-tier trigger evaluation; defaulting to ARCH_PROMOTED=true, SECURITY_PROMOTED=false." >&2
+     ARCH_PROMOTED=true
+     SECURITY_PROMOTED=false
+   else
+     # Security trigger: auth/credential/dependency paths
+     SECURITY_PROMOTED=false
+     if echo "$TINY_DIFF_NAMES" | grep -qE '(auth|passwords?|routes?/|/api/|credentials?|token|secret)' \
+       || echo "$TINY_DIFF_NAMES" | grep -qE '(^|/)(package\.json|go\.mod|composer\.json|requirements.*\.txt|pyproject\.toml|Gemfile|Pipfile|[Cc]argo\.toml)$' \
+       || echo "$TINY_DIFF_NAMES" | grep -qE '(^|/)\.env' \
+       || echo "$TINY_DIFF_NAMES" | grep -qE 'settings\.(py|ya?ml|json|toml)$'; then
+       SECURITY_PROMOTED=true
+     fi
 
-   # Architecture trigger: infra/CI files or cross-directory change
-   ARCH_PROMOTED=false
-   if git diff --name-only <base>...HEAD | grep -qE '(^|/)(Dockerfile|\.nvmrc|\.node-version|\.ddev/|\.github/workflows/|\.gitlab-ci\.yml|bitbucket-pipelines\.yml|lagoon/|helm/|k8s/|kubernetes/|terraform/|docker-compose)'; then
-     ARCH_PROMOTED=true
-   elif [[ $(git diff --name-only <base>...HEAD | awk -F/ '{print $1}' | sort -u | wc -l | tr -d ' ') -ge 2 ]]; then
-     ARCH_PROMOTED=true
+     # Architecture trigger: infra/CI files or cross-directory change
+     ARCH_PROMOTED=false
+     if echo "$TINY_DIFF_NAMES" | grep -qE '(^|/)(Dockerfile|\.nvmrc|\.node-version|\.ddev/|\.github/workflows/|\.gitlab-ci\.yml|bitbucket-pipelines\.yml|lagoon/|helm/|k8s/|kubernetes/|terraform/|docker-compose)'; then
+       ARCH_PROMOTED=true
+     elif [[ $(echo "$TINY_DIFF_NAMES" | awk -F/ '{print $1}' | sort -u | wc -l | tr -d ' ') -ge 2 ]]; then
+       ARCH_PROMOTED=true
+     fi
    fi
    ```
-   In `--pr` mode, prefix all git commands above with `git -C "$WORKTREE_PATH"`.
+   In `--pr` mode, prefix the `git diff` command with `git -C "$WORKTREE_PATH"`.
    These triggers only apply at TIER=tiny; at TIER=small or TIER=medium they are ignored.
    Surface both flags in Phase 5 metadata (e.g., `TIER=tiny — architecture-reviewer promoted by infra trigger`).
 
@@ -459,13 +474,16 @@ for candidate in \
 done
 
 CVE_JSON="[]"
+CVE_CHECK_FAILED=false
 if [[ -n "$CVE_SCRIPT" ]]; then
   CVE_JSON=$(bash "$CVE_SCRIPT" <<<"$MANIFEST_FILES") || {
     echo "WARNING: run-cve-check.sh ($CVE_SCRIPT) failed; CVE findings will be skipped." >&2
     CVE_JSON="[]"
+    CVE_CHECK_FAILED=true
   }
 else
   echo "WARNING: run-cve-check.sh not found. Tried: \$CLAUDE_PLUGIN_ROOT/scripts, \$CLAUDE_DIR/scripts, ~/.claude/scripts, and the marketplace install path. CVE check skipped. Install via '/plugins install comprehensive-review@tag1consulting' or './install.sh --local'." >&2
+  CVE_CHECK_FAILED=true
 fi
 ```
 
@@ -726,6 +744,7 @@ Note in terminal: "Review written to <path>"
    - If token counts are unavailable for a specific agent (e.g., toolkit agents that don't expose metadata), show "—" for those cells.
 8. Critical/High findings → "⚠ Address Critical/High findings before requesting review."
 9. Agent failures → "⚠ Review incomplete — <N> agent(s) failed."
+   If CVE_CHECK_FAILED=true → "⚠ CVE check did not run (script not found or execution failed) — dependency vulnerabilities not scanned." Show this even when CVE_JSON is [] so the user knows the empty result means 'check skipped', not 'no vulnerabilities'.
 10. No findings + no failures → "No significant issues found. Ready for review."
 11. claude-mem summary stored → "Review summary stored to claude-mem." (omit if MEM_AVAILABLE is false, mode is `--summary-only` or `--security-only`, or POST failed)
 


### PR DESCRIPTION
## Summary

Three P0 improvements from real-PR testing on `aftsoftwareteam/connect` (#3506 and #3502):

- **P0-1 — TIER=tiny auto-branch**: When the diff is under 50 lines AND ≤3 files, the skill now auto-selects a "tiny" tier. pr-summarizer routes to Haiku; architecture-reviewer and security-reviewer are skipped unless promoted by triggers (infra/CI paths for arch, auth/credential/dep-manifest paths for security); blind-hunter, edge-case-hunter, comment-analyzer, and type-design-analyzer are unconditionally skipped. FILE_DIGEST and PRIOR_REVIEW_CONTEXT are omitted. Estimated floor cost: ~$1 → ~$0.30 on tiny PRs.
- **P0-2 — Hardened CVE script path discovery**: Replaces the single `${CLAUDE_DIR:-$HOME/.claude}/scripts/run-cve-check.sh` lookup with an ordered 5-candidate search (`$CLAUDE_PLUGIN_ROOT/scripts` → `$CLAUDE_PLUGIN_ROOT/skills/.../scripts` → `$CLAUDE_DIR/scripts` → `$HOME/.claude/scripts` → known marketplace path). The warning message now lists all tried paths, making install failures diagnosable.
- **P0-3 — RELATED_FILES pointers**: When the diff touches version pins (`.nvmrc`, `package.json`, `composer.json`, etc.), Dockerfiles, or CI configs, the orchestrator now builds a `RELATED_FILES` list of adjacent files outside the diff that may have drifted. This is passed to architecture-reviewer and security-reviewer as an explicit directive. This would have surfaced the #3502 Critical (Node 22/24 drift in `lagoon/cli.dockerfile`) without requiring architecture-reviewer to autonomously discover the file via 3–4 tool calls.

**Interaction design:**
- `--quick` + TIER=tiny: stricter wins. Tiny further demotes pr-summarizer to Haiku on top of `--quick` skips.
- `--security-only`: always overrides TIER=tiny — security-reviewer runs regardless.
- `--depth deep` + TIER=tiny: applies only to trigger-promoted agents; does NOT un-skip unconditionally-skipped ones.
- RELATED_FILES is built and passed at all tiers, including TIER=tiny where it is the primary signal for promoted Opus agents.

Phase 5 now reports the computed diff tier, line/file counts, and per-agent promotion/skip reasons when TIER=tiny fires.

## Test plan

- [ ] Verify TIER=tiny fires on a trivial 1-2 line non-infra diff: only pr-summarizer (Haiku) + code-reviewer should run
- [ ] Verify a 1-line `.nvmrc` change: TIER=tiny + ARCH_PROMOTED=true → architecture-reviewer runs, receives RELATED_FILES pointing at adjacent Dockerfiles
- [ ] Verify PR #3502 equivalent (199-line tooling PR with `.nvmrc` bump): TIER=small (not tiny), RELATED_FILES includes `lagoon/cli.dockerfile`, Critical finding surfaces in ≤2 arch-reviewer tool calls
- [ ] Verify CVE path discovery: with `$CLAUDE_PLUGIN_ROOT` set to a directory with no script, falls through to `$HOME/.claude/scripts/` and finds the script
- [ ] Verify `--security-only` still runs security-reviewer on a tiny diff