### PR TITLE
chore: release v1.5.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "comprehensive-review",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "CodeRabbit-style PR review using parallel specialized agents. Produces structured PR summaries and severity-ranked findings from 10+ agents.",
   "author": {
     "name": "Tag1 Consulting",


### PR DESCRIPTION
## Summary

Bumps plugin version to 1.5.0 for the ai-pr-review parity release.

## Highlights (from PR #55)

- **Knowledge-cutoff guardrails** across all findings agents
- **`json-findings` structured output contract** with truncation salvage and element-wise recovery
- **Confidence scoring** (0–100) with `--min-confidence` flag (default 75)
- **Declarative suppressions** with verify-before-suppress (6 ecosystems: github-release, npm, pypi, go-module, cargo, docker-hub) + `--no-suppress` flag
- **Language profiles** — 9 per-language context blocks (Go, Python, TypeScript, PHP, Ruby, Rust, Java, C++, Shell)
- **`adversarial-general` agent** — new 7th Opus agent for completeness gaps
- **Static analyzers** — shellcheck, semgrep, trufflehog, ruff, golangci-lint as Phase 1b siblings
- **Default no-post** — all runs local unless `--pr`, `--create-pr`, `--post-summary`, or `--post-findings` is passed
- **Scripts relocated** to `skills/comprehensive-review/scripts/`

## Test plan

- [x] `./install.sh --local` succeeds
- [x] Tag `v1.5.0` after merge
- [ ] Create GitHub release
- [ ] Update `tag1consulting/claude-plugins` marketplace entry