### PR TITLE
chore: bump version to 1.6.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "comprehensive-review",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "CodeRabbit-style PR review using parallel specialized agents. Produces structured PR summaries and severity-ranked findings from 10+ agents.",
   "author": {
     "name": "Tag1 Consulting",


### PR DESCRIPTION
## Summary

Release v1.6.0 — ports ai-pr-review v0.7.0 improvements.

### What's new in v1.6.0

- **Knowledge-cutoff guardrail standardization** — Fixed adversarial-general missing the version-hallucination guardrail (bug). Upgraded all 5 custom findings agents to a standardized guardrail block with 4-item whitelist, concrete examples, and "omit entirely" instruction.
- **Trufflehog test-file demotion** — Unverified secrets in test/fixture/example files demoted from High/85 to Low/40. Verified secrets never demoted. Single-invocation performance optimization. Safety-net suppression rule added.
- **Ruby-org verify type** — New verify ecosystem for Ruby MRI version-hallucination suppressions via cache.ruby-lang.org.
- **Checkov IaC scanner** — New static analyzer for Terraform, k8s YAML, Dockerfiles, CloudFormation, Azure ARM. Content-sniff avoids checkov cold starts on non-IaC files. Opportunistic (silently skips if not installed).
- **Dependency bump** — actions/checkout v6

### Changes since v1.5.0

- PR #58: feat: port ai-pr-review v0.7.0 improvements
- PR #54: chore(deps): update actions/checkout action to v6