### PR TITLE
ci: standardize on container-action composite + wire Epic 3 inputs

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -29,71 +29,45 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Mask credentials
+      - name: Run AI review
+        uses: tag1consulting/ai-pr-review/container-action@main
         env:
-          _API_KEY: ${{ secrets.AI_REVIEW_API_KEY }}
-          _GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          _REGISTRY_TOKEN: ${{ secrets.GHCR_TOKEN }}
-        run: |
-          [[ -n "$_API_KEY" ]]        && echo "::add-mask::$_API_KEY"
-          [[ -n "$_GH_TOKEN" ]]       && echo "::add-mask::$_GH_TOKEN"
-          [[ -n "$_REGISTRY_TOKEN" ]] && echo "::add-mask::$_REGISTRY_TOKEN"
-
-      - name: Log in to GHCR
-        env:
-          REGISTRY_TOKEN: ${{ secrets.GHCR_TOKEN }}
-        run: echo "$REGISTRY_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
-
-      - name: Run AI review in container
-        env:
-          IMAGE: ghcr.io/tag1consulting/ai-pr-review:latest
-          AI_PROVIDER: ${{ vars.AI_REVIEW_PROVIDER || 'anthropic' }}
-          AI_REVIEW_MODE: >-
+          # ai-review-rescan label forces a full-diff re-review by setting
+          # FORCE_FULL_DIFF=true in the container env.  The composite
+          # action forwards this env var via `-e FORCE_FULL_DIFF` if set.
+          FORCE_FULL_DIFF: ${{ contains(github.event.pull_request.labels.*.name, 'ai-review-rescan') }}
+        with:
+          # vars.AI_REVIEW_IMAGE_TAG pins the container image (default 'latest';
+          # this repo dogfoods 'dev' ahead of the Epic 4 default-engine flip).
+          image-tag: ${{ vars.AI_REVIEW_IMAGE_TAG || 'latest' }}
+          registry-token: ${{ secrets.GHCR_TOKEN }}
+          provider: ${{ vars.AI_REVIEW_PROVIDER || 'anthropic' }}
+          api-key: ${{ secrets.AI_REVIEW_API_KEY }}
+          base-url: ${{ vars.AI_REVIEW_BASE_URL || '' }}
+          model-standard: ${{ vars.AI_REVIEW_MODEL_STANDARD || '' }}
+          model-premium: ${{ vars.AI_REVIEW_MODEL_PREMIUM || '' }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ github.event.pull_request.number }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
+          head-sha: ${{ github.event.pull_request.head.sha }}
+          review-mode: >-
             ${{
               (contains(github.event.pull_request.labels.*.name, 'ai-review-full') && 'full') ||
               'quick'
             }}
-          FORCE_FULL_DIFF: ${{ contains(github.event.pull_request.labels.*.name, 'ai-review-rescan') }}
-          AI_MODEL_STANDARD: ${{ vars.AI_REVIEW_MODEL_STANDARD || '' }}
-          AI_MODEL_PREMIUM: ${{ vars.AI_REVIEW_MODEL_PREMIUM || '' }}
-          OPENAI_BASE_URL: ${{ vars.AI_REVIEW_BASE_URL || '' }}
-          BEDROCK_API_URL: ${{ vars.AI_REVIEW_BASE_URL || '' }}
-          ANTHROPIC_API_KEY: ${{ secrets.AI_REVIEW_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.AI_REVIEW_API_KEY }}
-          GOOGLE_API_KEY: ${{ secrets.AI_REVIEW_API_KEY }}
-          BEDROCK_API_KEY: ${{ secrets.AI_REVIEW_API_KEY }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          docker pull "$IMAGE"
-          SUMMARY_MOUNT=()
-          if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-            SUMMARY_MOUNT=(-e GITHUB_STEP_SUMMARY -v "$GITHUB_STEP_SUMMARY:$GITHUB_STEP_SUMMARY")
-          fi
-          docker run --rm \
-            -e AI_PROVIDER \
-            -e AI_REVIEW_MODE \
-            -e FORCE_FULL_DIFF \
-            -e AI_MODEL_STANDARD \
-            -e AI_MODEL_PREMIUM \
-            -e ANTHROPIC_API_KEY \
-            -e OPENAI_API_KEY \
-            -e GOOGLE_API_KEY \
-            -e BEDROCK_API_KEY \
-            -e OPENAI_BASE_URL \
-            -e BEDROCK_API_URL \
-            -e GH_TOKEN \
-            -e GITHUB_REPOSITORY \
-            -e PR_NUMBER \
-            -e BASE_REF \
-            -e HEAD_SHA \
-            -e GITHUB_WORKSPACE=/workspace \
-            -v "$GITHUB_WORKSPACE:/workspace" \
-            "${SUMMARY_MOUNT[@]}" \
-            "$IMAGE"
+          # vars.AI_PR_REVIEW_ENGINE selects the compute engine (default 'bash';
+          # Epic 3 capabilities below require 'python').
+          engine: ${{ vars.AI_PR_REVIEW_ENGINE || 'bash' }}
+          # vars.AI_REVIEW_IGNORE_MERGE_COMMITS strips upstream base-branch
+          # merge commits before diffing (default false).
+          ignore-merge-commits: ${{ vars.AI_REVIEW_IGNORE_MERGE_COMMITS || 'false' }}
+          # --- Epic 3: opt-in capabilities (Python engine only) ---
+          # vars.AI_REVIEW_CONTEXT_ENRICHMENT injects tree-sitter symbol
+          # context into agent prompts (default false).
+          context-enrichment: ${{ vars.AI_REVIEW_CONTEXT_ENRICHMENT || 'false' }}
+          # vars.AI_REVIEW_FEEDBACK_LOOP loads recent /ai-pr-review feedback
+          # entries from the ai-pr-review-bot branch (default false).
+          feedback-loop: ${{ vars.AI_REVIEW_FEEDBACK_LOOP || 'false' }}
 
   cleanup-rescan-label:
     needs: review


### PR DESCRIPTION
## Summary

Two changes in one PR:

1. **Migrate from hand-rolled `docker run` to the `container-action` composite.** The previous workflow duplicated credential masking, GHCR login, summary mount, and the full `-e` plumbing inline. Every other internal repo uses the composite at `tag1consulting/ai-pr-review/container-action@main`; this brings claude-comprehensive-review onto the same call style. Net **-26 lines** while gaining functionality.

2. **Wire the Epic 3 capability inputs.** Five new inputs read from existing repo variables; all default to their existing values when the var is unset.

| Input | Reads | Currently set to |
|-------|-------|------------------|
| `image-tag` | `vars.AI_REVIEW_IMAGE_TAG` | `dev` |
| `engine` | `vars.AI_PR_REVIEW_ENGINE` | `python` |
| `ignore-merge-commits` | `vars.AI_REVIEW_IGNORE_MERGE_COMMITS` | `true` |
| `context-enrichment` | `vars.AI_REVIEW_CONTEXT_ENRICHMENT` | `true` (Capability A) |
| `feedback-loop` | `vars.AI_REVIEW_FEEDBACK_LOOP` | `true` (Capability C) |

## What's preserved

- `cleanup-rescan-label` job (this repo's custom auto-remove of the `ai-review-rescan` label after a review).
- `ai-review-rescan` / `ai-review-full` label triggers.
- `FORCE_FULL_DIFF` forwarding (now passed via the `env:` block on the composite step; the composite forwards it via `-e FORCE_FULL_DIFF` if set).
- Concurrency group cancellation.
- All existing repo-var overrides (provider, base-url, model overrides).

## Why

Standardization. The `container-action` composite at `@main` is the canonical entry point used by every other internal repo that consumes ai-pr-review. Centralizing the docker invocation there means: credential masking, GHCR login, env-var pass-through, and summary mount logic live in one place (`container-action/action.yml`) and stay consistent across consumers. New env vars only need to be added to the composite, not to every consumer's `docker run -e` list.

Also part of the Epic 3 / Epic 4 dogfooding rollout — see tag1consulting/ai-pr-review#197.

## Test plan

- [x] Default behavior unchanged when vars unset.
- [ ] On merge: next PR review uses `ghcr.io/tag1consulting/ai-pr-review:dev` with the Python engine + Capabilities A and C active.
- [ ] `ai-review-rescan` label still triggers a full-diff re-review and is auto-removed afterwards.