### PR TITLE
Fix #63: prefix owned agents with comprehensive-review: namespace (v1.6.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "comprehensive-review",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "CodeRabbit-style PR review using parallel specialized agents. Produces structured PR summaries and severity-ranked findings from 10+ agents.",
   "author": {
     "name": "Tag1 Consulting",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository purpose
 
-This repo distributes a Claude Code skill (`/comprehensive-review`) and six custom agents as a Claude Code plugin. The skill supports GitHub (including Enterprise), GitLab, and Bitbucket repositories. There is no build system, test suite, or compiled output — the deliverables are markdown files distributed via the `tag1consulting` plugin marketplace or copied into `~/.claude/` by a legacy install script.
+This repo distributes a Claude Code skill (`/comprehensive-review`) and six custom agents as a Claude Code plugin. The skill supports GitHub (including Enterprise), GitLab, and Bitbucket repositories. There is no build system, test suite, or compiled output — the deliverables are markdown files distributed via the `tag1consulting` plugin marketplace or installed locally via `install.sh`.
 
 ## Installation (for testing changes locally)
 
@@ -12,7 +12,7 @@ This repo distributes a Claude Code skill (`/comprehensive-review`) and six cust
 ./install.sh --local
 ```
 
-This copies files from the local working tree into `~/.claude/` without fetching from GitHub. Changes take effect immediately in the next Claude Code session. This is the recommended method for contributors testing local changes. For end-user installation, use `/plugins install comprehensive-review@tag1consulting` inside Claude Code.
+This installs files from the local working tree as a local Claude Code plugin under `~/.claude/plugins/cache/tag1consulting-local/comprehensive-review/<version>/`. Agents are registered under the `comprehensive-review:` namespace, matching the marketplace install exactly. Changes take effect after restarting Claude Code. This is the recommended method for contributors testing local changes. For end-user installation, use `/plugins install comprehensive-review@tag1consulting` inside Claude Code.
 
 ## Architecture
 
@@ -148,7 +148,7 @@ Key provider differences:
 
 ## Distribution
 
-This project is distributed as a Claude Code plugin via the `tag1consulting` marketplace (hosted at `tag1consulting/claude-plugins` on GitHub). The `install.sh` script is maintained as a legacy fallback.
+This project is distributed as a Claude Code plugin via the `tag1consulting` marketplace (hosted at `tag1consulting/claude-plugins` on GitHub). The `install.sh` script provides a local plugin install for development and testing.
 
 ### Version management
 
@@ -190,7 +190,7 @@ agents/architecture-reviewer.md                              ← architectural a
 agents/blind-hunter.md                                       ← context-free "fresh eyes" review (adapted from BMAD-METHOD)
 agents/edge-case-hunter.md                                   ← boundary-condition path tracing (adapted from BMAD-METHOD)
 agents/adversarial-general.md                                ← holistic completeness/operational review (adapted from BMAD-METHOD)
-install.sh                                                   ← legacy file-copy installer (recommends plugin install)
+install.sh                                                   ← local plugin installer (for development; use /plugins install for end users)
 ```
 
 ## Editing guidelines

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Then inside Claude Code, install the plugin and its dependency:
 /plugins install pr-review-toolkit@claude-plugins-official
 ```
 
-### Option 2: Install script (legacy)
+### Option 2: Install script
 
 ```bash
 git clone https://github.com/tag1consulting/claude-comprehensive-review.git
@@ -92,7 +92,7 @@ cd claude-comprehensive-review
 ./install.sh
 ```
 
-The script automatically installs the latest release, fetching files directly from GitHub. The `pr-review-toolkit` plugin is installed automatically as well.
+The script installs comprehensive-review as a local Claude Code plugin under `~/.claude/plugins/cache/tag1consulting-local/`. Agents are registered under the `comprehensive-review:` namespace, matching the marketplace install. The `pr-review-toolkit` plugin is installed automatically as well. Restart Claude Code after running.
 
 **Install a specific version:**
 
@@ -114,34 +114,43 @@ The script automatically installs the latest release, fetching files directly fr
 
 ### Option 3: Manual installation
 
-Copy files to your Claude config directory (default: `~/.claude`):
+> **Note:** As of v1.6.1, agents must be installed under the `comprehensive-review:` plugin namespace. The install script (Option 2) handles this automatically. For manual installs, you must lay down the full plugin tree shown below, then update `~/.claude/plugins/installed_plugins.json` to register it — or use the install script instead.
 
 ```bash
+PLUGIN_DIR=~/.claude/plugins/cache/tag1consulting-local/comprehensive-review/<version>
+
+# Plugin manifest
+mkdir -p "$PLUGIN_DIR/.claude-plugin"
+cp .claude-plugin/plugin.json "$PLUGIN_DIR/.claude-plugin/"
+
 # Skill
-mkdir -p ~/.claude/skills/comprehensive-review
-cp skills/comprehensive-review/SKILL.md ~/.claude/skills/comprehensive-review/
-cp skills/comprehensive-review/HELP.md ~/.claude/skills/comprehensive-review/
-cp skills/comprehensive-review/PROVIDERS.md ~/.claude/skills/comprehensive-review/
-cp skills/comprehensive-review/SEVERITY.md ~/.claude/skills/comprehensive-review/
+mkdir -p "$PLUGIN_DIR/skills/comprehensive-review"
+cp skills/comprehensive-review/SKILL.md "$PLUGIN_DIR/skills/comprehensive-review/"
+cp skills/comprehensive-review/HELP.md "$PLUGIN_DIR/skills/comprehensive-review/"
+cp skills/comprehensive-review/PROVIDERS.md "$PLUGIN_DIR/skills/comprehensive-review/"
+cp skills/comprehensive-review/SEVERITY.md "$PLUGIN_DIR/skills/comprehensive-review/"
+cp skills/comprehensive-review/suppressions.json "$PLUGIN_DIR/skills/comprehensive-review/"
+cp -r skills/comprehensive-review/language-profiles "$PLUGIN_DIR/skills/comprehensive-review/"
 
 # Agents
-mkdir -p ~/.claude/agents
-cp agents/pr-summarizer.md ~/.claude/agents/
-cp agents/issue-linker.md ~/.claude/agents/
-cp agents/security-reviewer.md ~/.claude/agents/
-cp agents/architecture-reviewer.md ~/.claude/agents/
-cp agents/blind-hunter.md ~/.claude/agents/
-cp agents/edge-case-hunter.md ~/.claude/agents/
+mkdir -p "$PLUGIN_DIR/agents"
+cp agents/pr-summarizer.md "$PLUGIN_DIR/agents/"
+cp agents/issue-linker.md "$PLUGIN_DIR/agents/"
+cp agents/security-reviewer.md "$PLUGIN_DIR/agents/"
+cp agents/architecture-reviewer.md "$PLUGIN_DIR/agents/"
+cp agents/blind-hunter.md "$PLUGIN_DIR/agents/"
+cp agents/edge-case-hunter.md "$PLUGIN_DIR/agents/"
+cp agents/adversarial-general.md "$PLUGIN_DIR/agents/"
 
 # Scripts
-mkdir -p ~/.claude/skills/comprehensive-review/scripts
+mkdir -p "$PLUGIN_DIR/skills/comprehensive-review/scripts"
 for s in skills/comprehensive-review/scripts/*.sh; do
-  cp "$s" ~/.claude/skills/comprehensive-review/scripts/
-  chmod +x ~/.claude/skills/comprehensive-review/scripts/"$(basename "$s")"
+  cp "$s" "$PLUGIN_DIR/skills/comprehensive-review/scripts/"
+  chmod +x "$PLUGIN_DIR/skills/comprehensive-review/scripts/$(basename "$s")"
 done
 ```
 
-Then install the dependency plugin inside Claude Code:
+Then register the plugin in `~/.claude/plugins/installed_plugins.json` (add or update the `comprehensive-review@tag1consulting` key) and install the dependency plugin inside Claude Code:
 
 ```
 /plugins install pr-review-toolkit@claude-plugins-official
@@ -482,9 +491,9 @@ minimum-findings mandate, and integrate tightly with our manifest and context-pa
 /plugins update comprehensive-review@tag1consulting
 ```
 
-**Legacy install:**
+**Install script:**
 
-Pull the latest version and re-run `./install.sh`. Existing agent files will be overwritten.
+Pull the latest version and re-run `./install.sh`. Existing files will be overwritten.
 
 ## Uninstalling
 
@@ -494,15 +503,10 @@ Pull the latest version and re-run `./install.sh`. Existing agent files will be 
 /plugins uninstall comprehensive-review@tag1consulting
 ```
 
-**Legacy install:**
+**Install script:**
 
 ```bash
-rm -rf ~/.claude/skills/comprehensive-review
-rm ~/.claude/agents/pr-summarizer.md
-rm ~/.claude/agents/issue-linker.md
-rm ~/.claude/agents/security-reviewer.md
-rm ~/.claude/agents/architecture-reviewer.md
-rm ~/.claude/agents/blind-hunter.md
-rm ~/.claude/agents/edge-case-hunter.md
-rm ~/.claude/agents/adversarial-general.md
+rm -rf ~/.claude/plugins/cache/tag1consulting-local/comprehensive-review
 ```
+
+Then remove the `comprehensive-review@tag1consulting` entry from `~/.claude/plugins/installed_plugins.json`.

--- a/install.sh
+++ b/install.sh
@@ -191,6 +191,29 @@ INSTALLED_PLUGINS_FILE="$PLUGINS_DIR/installed_plugins.json"
 info "Plugin install path: $PLUGIN_DIR"
 
 # ---------------------------------------------------------------------------
+# Remove legacy flat-path install (pre-v1.6.1)
+# ---------------------------------------------------------------------------
+# Prior versions of install.sh copied agents flat into ~/.claude/agents/ and
+# the skill into ~/.claude/skills/comprehensive-review/. These bare-name agent
+# files conflict with the plugin-namespaced registration and must be removed.
+
+LEGACY_SKILL_DIR="$CLAUDE_DIR/skills/comprehensive-review"
+LEGACY_AGENTS_DIR="$CLAUDE_DIR/agents"
+
+if [[ -f "$LEGACY_SKILL_DIR/SKILL.md" ]]; then
+  rm -rf "$LEGACY_SKILL_DIR"
+  info "Removed legacy skill directory → $LEGACY_SKILL_DIR"
+fi
+
+for agent in pr-summarizer issue-linker security-reviewer architecture-reviewer blind-hunter edge-case-hunter adversarial-general; do
+  legacy_agent="$LEGACY_AGENTS_DIR/${agent}.md"
+  if [[ -f "$legacy_agent" ]]; then
+    rm -f "$legacy_agent"
+    info "Removed legacy agent file  → $legacy_agent"
+  fi
+done
+
+# ---------------------------------------------------------------------------
 # Helper: install one file from GitHub or local
 # ---------------------------------------------------------------------------
 

--- a/install.sh
+++ b/install.sh
@@ -1,18 +1,26 @@
 #!/usr/bin/env bash
-# install.sh — installs the comprehensive-review skill and its agents
-# into the current user's Claude Code configuration directory.
+# install.sh — installs comprehensive-review as a local plugin
+# into the Claude Code plugin cache directory.
 #
 # Usage: install.sh [--version <tag|main>] [--local]
 #
 #   (no flags)          Install the latest release from GitHub
 #   --version <tag>     Install a specific release (e.g. v1.0.0)
 #   --version main      Install the development version from the main branch
-#   --local             Install from local files (skips GitHub; for development)
+#   --local             Install from local files (for development / dogfood)
+#
+# For end users, the recommended install method is:
+#   /plugins install comprehensive-review@tag1consulting
+#
+# This script installs comprehensive-review as a local plugin so that agents
+# are registered under the same comprehensive-review: namespace as a marketplace
+# install. This is the supported path for local development and testing.
 
 set -euo pipefail
 
 REPO="tag1consulting/claude-comprehensive-review"
 CLAUDE_DIR="${CLAUDE_DIR:-$HOME/.claude}"
+PLUGINS_DIR="$CLAUDE_DIR/plugins"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 RED='\033[0;31m'
@@ -53,6 +61,13 @@ while [[ $# -gt 0 ]]; do
       echo "  --version <tag>     Install a specific release (e.g. v1.0.0)"
       echo "  --version main      Install the development version from main branch"
       echo "  --local             Install from local files (for development)"
+      echo ""
+      echo "This script installs comprehensive-review as a local Claude Code plugin"
+      echo "under ~/.claude/plugins/cache/tag1consulting-local/. Agents are registered"
+      echo "under the comprehensive-review: namespace, matching the marketplace install."
+      echo ""
+      echo "For end users, prefer the marketplace install inside Claude Code:"
+      echo "  /plugins install comprehensive-review@tag1consulting"
       exit 0
       ;;
     *)
@@ -63,22 +78,17 @@ while [[ $# -gt 0 ]]; do
 done
 
 # ---------------------------------------------------------------------------
-# Recommend plugin install
-# ---------------------------------------------------------------------------
-
-info ""
-info "NOTE: Plugin install is now the recommended method:"
-info "  /plugins install comprehensive-review@tag1consulting"
-info ""
-info "Continuing with legacy file-copy installation..."
-info ""
-
-# ---------------------------------------------------------------------------
 # Pre-flight checks
 # ---------------------------------------------------------------------------
 
 if ! command -v claude &>/dev/null; then
   error "Claude Code CLI not found. Install it first: https://claude.ai/code"
+  exit 1
+fi
+
+if ! command -v jq &>/dev/null; then
+  error "jq not found. Required to update plugin registration."
+  error "Install from: https://stedolan.github.io/jq/"
   exit 1
 fi
 
@@ -100,7 +110,13 @@ fi
 
 if [[ ! -d "$CLAUDE_DIR" ]]; then
   error "Claude config directory not found at $CLAUDE_DIR."
-  error "Run Claude Code at least once before installing this skill."
+  error "Run Claude Code at least once before installing this plugin."
+  exit 1
+fi
+
+if [[ ! -d "$PLUGINS_DIR" ]]; then
+  error "Claude plugins directory not found at $PLUGINS_DIR."
+  error "Run Claude Code at least once, then install any plugin from the marketplace before using this script."
   exit 1
 fi
 
@@ -153,6 +169,28 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Determine plugin version string
+# ---------------------------------------------------------------------------
+
+if [[ "$LOCAL" == true ]]; then
+  # Read version from local plugin.json
+  PLUGIN_VERSION=$(jq -r '.version' "$SCRIPT_DIR/.claude-plugin/plugin.json" 2>/dev/null || echo "local")
+elif [[ "$REF" =~ ^v[0-9] ]]; then
+  PLUGIN_VERSION="${REF#v}"  # strip leading 'v'
+else
+  PLUGIN_VERSION="$REF"
+fi
+
+# Plugin install path: use tag1consulting-local owner to avoid collision with marketplace install
+PLUGIN_OWNER="tag1consulting-local"
+PLUGIN_NAME="comprehensive-review"
+PLUGIN_KEY="comprehensive-review@tag1consulting"
+PLUGIN_DIR="$PLUGINS_DIR/cache/$PLUGIN_OWNER/$PLUGIN_NAME/$PLUGIN_VERSION"
+INSTALLED_PLUGINS_FILE="$PLUGINS_DIR/installed_plugins.json"
+
+info "Plugin install path: $PLUGIN_DIR"
+
+# ---------------------------------------------------------------------------
 # Helper: install one file from GitHub or local
 # ---------------------------------------------------------------------------
 
@@ -177,56 +215,88 @@ install_file() {
 }
 
 # ---------------------------------------------------------------------------
+# Install plugin manifest
+# ---------------------------------------------------------------------------
+
+install_file ".claude-plugin/plugin.json" "$PLUGIN_DIR/.claude-plugin/plugin.json"
+info "Installed manifest → $PLUGIN_DIR/.claude-plugin/plugin.json"
+
+# ---------------------------------------------------------------------------
 # Install skill
 # ---------------------------------------------------------------------------
 
 install_file "skills/comprehensive-review/SKILL.md" \
-  "$CLAUDE_DIR/skills/comprehensive-review/SKILL.md"
+  "$PLUGIN_DIR/skills/comprehensive-review/SKILL.md"
 install_file "skills/comprehensive-review/HELP.md" \
-  "$CLAUDE_DIR/skills/comprehensive-review/HELP.md"
+  "$PLUGIN_DIR/skills/comprehensive-review/HELP.md"
 install_file "skills/comprehensive-review/PROVIDERS.md" \
-  "$CLAUDE_DIR/skills/comprehensive-review/PROVIDERS.md"
+  "$PLUGIN_DIR/skills/comprehensive-review/PROVIDERS.md"
 install_file "skills/comprehensive-review/SEVERITY.md" \
-  "$CLAUDE_DIR/skills/comprehensive-review/SEVERITY.md"
+  "$PLUGIN_DIR/skills/comprehensive-review/SEVERITY.md"
 install_file "skills/comprehensive-review/suppressions.json" \
-  "$CLAUDE_DIR/skills/comprehensive-review/suppressions.json"
+  "$PLUGIN_DIR/skills/comprehensive-review/suppressions.json"
 
 # Install language profiles
-mkdir -p "$CLAUDE_DIR/skills/comprehensive-review/language-profiles"
+mkdir -p "$PLUGIN_DIR/skills/comprehensive-review/language-profiles"
 for profile in go.md python.md typescript.md php.md ruby.md rust.md java.md c++.md shell.md; do
   install_file "skills/comprehensive-review/language-profiles/${profile}" \
-    "$CLAUDE_DIR/skills/comprehensive-review/language-profiles/${profile}"
+    "$PLUGIN_DIR/skills/comprehensive-review/language-profiles/${profile}"
 done
 
-info "Installed skill  → $CLAUDE_DIR/skills/comprehensive-review/"
+info "Installed skill  → $PLUGIN_DIR/skills/comprehensive-review/"
 
 # ---------------------------------------------------------------------------
 # Install agents
 # ---------------------------------------------------------------------------
 
+mkdir -p "$PLUGIN_DIR/agents"
 for agent in pr-summarizer issue-linker security-reviewer architecture-reviewer blind-hunter edge-case-hunter adversarial-general; do
-  dest="$CLAUDE_DIR/agents/${agent}.md"
-  if [[ -f "$dest" ]]; then
-    warn "Agent already exists, overwriting: $dest"
-  fi
-  install_file "agents/${agent}.md" "$dest"
-  info "Installed agent  → $dest"
+  install_file "agents/${agent}.md" "$PLUGIN_DIR/agents/${agent}.md"
+  info "Installed agent  → $PLUGIN_DIR/agents/${agent}.md"
 done
 
 # ---------------------------------------------------------------------------
 # Install scripts
 # ---------------------------------------------------------------------------
 
-mkdir -p "$CLAUDE_DIR/skills/comprehensive-review/scripts"
+mkdir -p "$PLUGIN_DIR/skills/comprehensive-review/scripts"
 for script in run-cve-check.sh run-shellcheck.sh run-semgrep.sh run-trufflehog.sh run-ruff.sh run-golangci-lint.sh run-checkov.sh; do
-  dest="$CLAUDE_DIR/skills/comprehensive-review/scripts/${script}"
-  if [[ -f "$dest" ]]; then
-    warn "Script already exists, overwriting: $dest"
-  fi
-  install_file "skills/comprehensive-review/scripts/${script}" "$dest"
-  chmod +x "$dest"
-  info "Installed script → $dest"
+  install_file "skills/comprehensive-review/scripts/${script}" \
+    "$PLUGIN_DIR/skills/comprehensive-review/scripts/${script}"
+  chmod +x "$PLUGIN_DIR/skills/comprehensive-review/scripts/${script}"
+  info "Installed script → $PLUGIN_DIR/skills/comprehensive-review/scripts/${script}"
 done
+
+# ---------------------------------------------------------------------------
+# Register plugin in installed_plugins.json
+# ---------------------------------------------------------------------------
+
+NOW=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+
+if [[ ! -f "$INSTALLED_PLUGINS_FILE" ]]; then
+  error "installed_plugins.json not found at $INSTALLED_PLUGINS_FILE."
+  error "Run Claude Code at least once and install any marketplace plugin before using this script."
+  exit 1
+fi
+
+# Upsert: set the plugin entry to a single-element array with this install.
+# Uses jq to idempotently replace any existing entry for PLUGIN_KEY.
+UPDATED=$(jq \
+  --arg key "$PLUGIN_KEY" \
+  --arg path "$PLUGIN_DIR" \
+  --arg ver "$PLUGIN_VERSION" \
+  --arg now "$NOW" \
+  '.plugins[$key] = [{
+    "scope": "user",
+    "installPath": $path,
+    "version": $ver,
+    "installedAt": $now,
+    "lastUpdated": $now
+  }]' \
+  "$INSTALLED_PLUGINS_FILE")
+
+echo "$UPDATED" > "$INSTALLED_PLUGINS_FILE"
+info "Registered plugin → $INSTALLED_PLUGINS_FILE (key: $PLUGIN_KEY)"
 
 # ---------------------------------------------------------------------------
 # Install pr-review-toolkit plugin
@@ -246,13 +316,18 @@ fi
 
 echo ""
 info "Installation complete."
-if [[ "$LOCAL" != true ]]; then
+if [[ "$LOCAL" == true ]]; then
+  info "Installed local version ${BOLD}${PLUGIN_VERSION}${NC} as plugin."
+else
   info "Installed: ${BOLD}${REF}${NC}"
 fi
 echo ""
-echo "  Usage:"
+echo "  Restart Claude Code to activate the plugin, then:"
 echo "    /comprehensive-review               # full review, everything local"
 echo "    /comprehensive-review --quick       # skip expensive agents, ~75% cheaper"
 echo "    /comprehensive-review --local       # review only, no GitHub operations"
 echo "    /comprehensive-review --help        # show all flags"
+echo ""
+warn "NOTE: For end users, the recommended install is inside Claude Code:"
+warn "  /plugins install comprehensive-review@tag1consulting"
 echo ""

--- a/install.sh
+++ b/install.sh
@@ -114,6 +114,11 @@ if [[ ! -d "$CLAUDE_DIR" ]]; then
   exit 1
 fi
 
+if [[ -e "$PLUGINS_DIR" && ! -d "$PLUGINS_DIR" ]]; then
+  error "$PLUGINS_DIR exists but is not a directory."
+  exit 1
+fi
+
 if [[ ! -d "$PLUGINS_DIR" ]]; then
   error "Claude plugins directory not found at $PLUGINS_DIR."
   error "Run Claude Code at least once, then install any plugin from the marketplace before using this script."
@@ -181,8 +186,9 @@ fi
 # ---------------------------------------------------------------------------
 
 if [[ "$LOCAL" == true ]]; then
-  # Read version from local plugin.json
-  PLUGIN_VERSION=$(jq -r '.version' "$SCRIPT_DIR/.claude-plugin/plugin.json" 2>/dev/null || echo "local")
+  # Use a fixed slug so re-runs after a version bump always install to the
+  # same path; avoids accumulating orphaned plugin cache directories.
+  PLUGIN_VERSION="local"
 elif [[ "$REF" =~ ^v[0-9] ]]; then
   PLUGIN_VERSION="${REF#v}"  # strip leading 'v'
 else
@@ -316,9 +322,10 @@ UPDATED=$(jq \
     "installedAt": $now,
     "lastUpdated": $now
   }]' \
-  "$INSTALLED_PLUGINS_FILE")
+  "$INSTALLED_PLUGINS_FILE") || { error "Failed to parse installed_plugins.json (jq error)"; exit 1; }
 
-echo "$UPDATED" > "$INSTALLED_PLUGINS_FILE"
+_tmp_plugins=$(mktemp "${INSTALLED_PLUGINS_FILE}.XXXXXX")
+echo "$UPDATED" > "$_tmp_plugins" && mv "$_tmp_plugins" "$INSTALLED_PLUGINS_FILE"
 info "Registered plugin → $INSTALLED_PLUGINS_FILE (key: $PLUGIN_KEY)"
 
 # ---------------------------------------------------------------------------

--- a/install.sh
+++ b/install.sh
@@ -128,7 +128,7 @@ fi
 INSTALLED_PLUGINS_FILE="$PLUGINS_DIR/installed_plugins.json"
 
 if [[ ! -f "$INSTALLED_PLUGINS_FILE" ]]; then
-  echo '{"plugins":{}}' > "$INSTALLED_PLUGINS_FILE"
+  echo '{"version":2,"plugins":{}}' > "$INSTALLED_PLUGINS_FILE"
   info "Created $INSTALLED_PLUGINS_FILE (first plugin registration)"
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -120,6 +120,14 @@ if [[ ! -d "$PLUGINS_DIR" ]]; then
   exit 1
 fi
 
+INSTALLED_PLUGINS_FILE="$PLUGINS_DIR/installed_plugins.json"
+
+if [[ ! -f "$INSTALLED_PLUGINS_FILE" ]]; then
+  error "installed_plugins.json not found at $INSTALLED_PLUGINS_FILE."
+  error "Run Claude Code at least once and install any marketplace plugin before using this script."
+  exit 1
+fi
+
 # ---------------------------------------------------------------------------
 # Resolve the ref (tag or branch) to install from
 # ---------------------------------------------------------------------------
@@ -186,8 +194,6 @@ PLUGIN_OWNER="tag1consulting-local"
 PLUGIN_NAME="comprehensive-review"
 PLUGIN_KEY="comprehensive-review@tag1consulting"
 PLUGIN_DIR="$PLUGINS_DIR/cache/$PLUGIN_OWNER/$PLUGIN_NAME/$PLUGIN_VERSION"
-INSTALLED_PLUGINS_FILE="$PLUGINS_DIR/installed_plugins.json"
-
 info "Plugin install path: $PLUGIN_DIR"
 
 # ---------------------------------------------------------------------------
@@ -295,12 +301,6 @@ done
 # ---------------------------------------------------------------------------
 
 NOW=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
-
-if [[ ! -f "$INSTALLED_PLUGINS_FILE" ]]; then
-  error "installed_plugins.json not found at $INSTALLED_PLUGINS_FILE."
-  error "Run Claude Code at least once and install any marketplace plugin before using this script."
-  exit 1
-fi
 
 # Upsert: set the plugin entry to a single-element array with this install.
 # Uses jq to idempotently replace any existing entry for PLUGIN_KEY.

--- a/install.sh
+++ b/install.sh
@@ -128,9 +128,8 @@ fi
 INSTALLED_PLUGINS_FILE="$PLUGINS_DIR/installed_plugins.json"
 
 if [[ ! -f "$INSTALLED_PLUGINS_FILE" ]]; then
-  error "installed_plugins.json not found at $INSTALLED_PLUGINS_FILE."
-  error "Run Claude Code at least once and install any marketplace plugin before using this script."
-  exit 1
+  echo '{"plugins":{}}' > "$INSTALLED_PLUGINS_FILE"
+  info "Created $INSTALLED_PLUGINS_FILE (first plugin registration)"
 fi
 
 # ---------------------------------------------------------------------------

--- a/skills/comprehensive-review/SKILL.md
+++ b/skills/comprehensive-review/SKILL.md
@@ -171,8 +171,8 @@ Note: The `mcp__github-pat__*` tools in the `allowed-tools` frontmatter are only
    ```bash
    LANGUAGE_PROFILES=""
    PROFILE_DIR="${CLAUDE_PLUGIN_ROOT:-}/skills/comprehensive-review/language-profiles"
-   # Fallback for local installs
-   [[ ! -d "$PROFILE_DIR" ]] && PROFILE_DIR="${CLAUDE_DIR:-}/../skills/comprehensive-review/language-profiles"
+   # Fallback for local installs (install.sh --local uses a fixed "local" version slug)
+   [[ ! -d "$PROFILE_DIR" ]] && PROFILE_DIR="$HOME/.claude/plugins/cache/tag1consulting-local/comprehensive-review/local/skills/comprehensive-review/language-profiles"
    [[ ! -d "$PROFILE_DIR" ]] && PROFILE_DIR="$HOME/.claude/skills/comprehensive-review/language-profiles"
    if [[ -d "$PROFILE_DIR" ]]; then
      for lang in $(echo "$LANGUAGES" | tr ',' '\n' | tr -d ' ' | tr '[:upper:]' '[:lower:]'); do
@@ -268,7 +268,7 @@ Note: The `mcp__github-pat__*` tools in the `allowed-tools` frontmatter are only
    SUPPRESSION_RULES="[]"
    # Global rules (shipped with the skill)
    GLOBAL_SUPP="${CLAUDE_PLUGIN_ROOT:-}/skills/comprehensive-review/suppressions.json"
-   [[ ! -f "$GLOBAL_SUPP" ]] && GLOBAL_SUPP="${CLAUDE_DIR:-}/../skills/comprehensive-review/suppressions.json"
+   [[ ! -f "$GLOBAL_SUPP" ]] && GLOBAL_SUPP="$HOME/.claude/plugins/cache/tag1consulting-local/comprehensive-review/local/skills/comprehensive-review/suppressions.json"
    [[ ! -f "$GLOBAL_SUPP" ]] && GLOBAL_SUPP="$HOME/.claude/skills/comprehensive-review/suppressions.json"
    # Local override (repo-specific rules)
    LOCAL_SUPP=".claude/comprehensive-review/suppressions.json"
@@ -553,7 +553,7 @@ Path resolution order: `$CLAUDE_PLUGIN_ROOT` (set by the plugin harness when the
 Detect script root (same priority chain as CVE script):
 ```bash
 SCRIPTS_DIR="${CLAUDE_PLUGIN_ROOT:-}/skills/comprehensive-review/scripts"
-[[ ! -d "$SCRIPTS_DIR" ]] && SCRIPTS_DIR="${CLAUDE_DIR:-}/skills/comprehensive-review/scripts"
+[[ ! -d "$SCRIPTS_DIR" ]] && SCRIPTS_DIR="$HOME/.claude/plugins/cache/tag1consulting-local/comprehensive-review/local/skills/comprehensive-review/scripts"
 [[ ! -d "$SCRIPTS_DIR" ]] && SCRIPTS_DIR="$HOME/.claude/skills/comprehensive-review/scripts"
 ```
 

--- a/skills/comprehensive-review/SKILL.md
+++ b/skills/comprehensive-review/SKILL.md
@@ -171,8 +171,11 @@ Note: The `mcp__github-pat__*` tools in the `allowed-tools` frontmatter are only
    ```bash
    LANGUAGE_PROFILES=""
    PROFILE_DIR="${CLAUDE_PLUGIN_ROOT:-}/skills/comprehensive-review/language-profiles"
-   # Fallback for local installs (install.sh --local uses a fixed "local" version slug)
-   [[ ! -d "$PROFILE_DIR" ]] && PROFILE_DIR="$HOME/.claude/plugins/cache/tag1consulting-local/comprehensive-review/local/skills/comprehensive-review/language-profiles"
+   # Fallback for install.sh installs (any version slug under tag1consulting-local)
+   if [[ ! -d "$PROFILE_DIR" ]]; then
+     _cr_fallback=$(ls -d "$HOME/.claude/plugins/cache/tag1consulting-local/comprehensive-review/"*/skills/comprehensive-review/language-profiles 2>/dev/null | head -1)
+     [[ -n "$_cr_fallback" ]] && PROFILE_DIR="$_cr_fallback"
+   fi
    [[ ! -d "$PROFILE_DIR" ]] && PROFILE_DIR="$HOME/.claude/skills/comprehensive-review/language-profiles"
    if [[ -d "$PROFILE_DIR" ]]; then
      for lang in $(echo "$LANGUAGES" | tr ',' '\n' | tr -d ' ' | tr '[:upper:]' '[:lower:]'); do
@@ -268,7 +271,11 @@ Note: The `mcp__github-pat__*` tools in the `allowed-tools` frontmatter are only
    SUPPRESSION_RULES="[]"
    # Global rules (shipped with the skill)
    GLOBAL_SUPP="${CLAUDE_PLUGIN_ROOT:-}/skills/comprehensive-review/suppressions.json"
-   [[ ! -f "$GLOBAL_SUPP" ]] && GLOBAL_SUPP="$HOME/.claude/plugins/cache/tag1consulting-local/comprehensive-review/local/skills/comprehensive-review/suppressions.json"
+   # Fallback for install.sh installs (any version slug under tag1consulting-local)
+   if [[ ! -f "$GLOBAL_SUPP" ]]; then
+     _cr_fallback=$(ls -d "$HOME/.claude/plugins/cache/tag1consulting-local/comprehensive-review/"*/skills/comprehensive-review/suppressions.json 2>/dev/null | head -1)
+     [[ -n "$_cr_fallback" ]] && GLOBAL_SUPP="$_cr_fallback"
+   fi
    [[ ! -f "$GLOBAL_SUPP" ]] && GLOBAL_SUPP="$HOME/.claude/skills/comprehensive-review/suppressions.json"
    # Local override (repo-specific rules)
    LOCAL_SUPP=".claude/comprehensive-review/suppressions.json"
@@ -553,7 +560,11 @@ Path resolution order: `$CLAUDE_PLUGIN_ROOT` (set by the plugin harness when the
 Detect script root (same priority chain as CVE script):
 ```bash
 SCRIPTS_DIR="${CLAUDE_PLUGIN_ROOT:-}/skills/comprehensive-review/scripts"
-[[ ! -d "$SCRIPTS_DIR" ]] && SCRIPTS_DIR="$HOME/.claude/plugins/cache/tag1consulting-local/comprehensive-review/local/skills/comprehensive-review/scripts"
+# Fallback for install.sh installs (any version slug under tag1consulting-local)
+if [[ ! -d "$SCRIPTS_DIR" ]]; then
+  _cr_fallback=$(ls -d "$HOME/.claude/plugins/cache/tag1consulting-local/comprehensive-review/"*/skills/comprehensive-review/scripts 2>/dev/null | head -1)
+  [[ -n "$_cr_fallback" ]] && SCRIPTS_DIR="$_cr_fallback"
+fi
 [[ ! -d "$SCRIPTS_DIR" ]] && SCRIPTS_DIR="$HOME/.claude/skills/comprehensive-review/scripts"
 ```
 

--- a/skills/comprehensive-review/SKILL.md
+++ b/skills/comprehensive-review/SKILL.md
@@ -407,22 +407,22 @@ Produce slices via `mktemp /tmp/cr-slice-<agent>-XXXXXXXX.txt` and `git diff <ba
 
 **Model assignments** — the table below is the source of truth. Always specify `model:` and `subagent_type:` explicitly when spawning agents via the Agent tool. If this table disagrees with an agent's frontmatter `model:` field, this table wins — the frontmatter is a standalone default for agents running outside this skill.
 
-**CRITICAL — namespace**: Use the `subagent_type` values from this table **verbatim**. Do NOT prepend `comprehensive-review:` to any agent name. Agents in `pr-review-toolkit:` must be spawned as `pr-review-toolkit:code-reviewer`, `pr-review-toolkit:silent-failure-hunter`, etc. — never as `comprehensive-review:code-reviewer`. The correct values are in the table below.
+**CRITICAL — namespace**: Use the `subagent_type` values from this table **verbatim**, including plugin-namespace prefixes. Owned agents are spawned as `comprehensive-review:<name>` (e.g. `comprehensive-review:pr-summarizer`); toolkit agents as `pr-review-toolkit:<name>`. Both prefixes are mandatory — the plugin install registers all agents under their plugin namespace, and spawning bare (`pr-summarizer`) will fail with `Agent type not found`. If a spawn fails with that error, abort and report the misconfiguration — do NOT retry with a different namespace.
 
 | Agent | subagent_type | Model (depth=normal) | Model (depth=deep) |
 |-------|--------------|----------------------|---------------------|
-| pr-summarizer | `pr-summarizer` | sonnet | sonnet |
+| pr-summarizer | `comprehensive-review:pr-summarizer` | sonnet | sonnet |
 | code-reviewer | `pr-review-toolkit:code-reviewer` | sonnet | sonnet |
-| architecture-reviewer | `architecture-reviewer` | opus | opus |
-| security-reviewer | `security-reviewer` | opus | opus |
-| blind-hunter | `blind-hunter` | sonnet | **opus** |
-| edge-case-hunter | `edge-case-hunter` | sonnet | **opus** |
+| architecture-reviewer | `comprehensive-review:architecture-reviewer` | opus | opus |
+| security-reviewer | `comprehensive-review:security-reviewer` | opus | opus |
+| blind-hunter | `comprehensive-review:blind-hunter` | sonnet | **opus** |
+| edge-case-hunter | `comprehensive-review:edge-case-hunter` | sonnet | **opus** |
 | silent-failure-hunter | `pr-review-toolkit:silent-failure-hunter` | sonnet | sonnet |
 | pr-test-analyzer | `pr-review-toolkit:pr-test-analyzer` | sonnet | sonnet |
 | comment-analyzer | `pr-review-toolkit:comment-analyzer` | sonnet | sonnet |
 | type-design-analyzer | `pr-review-toolkit:type-design-analyzer` | sonnet | sonnet |
-| adversarial-general | `adversarial-general` | opus | opus |
-| issue-linker | `issue-linker` | haiku | haiku |
+| adversarial-general | `comprehensive-review:adversarial-general` | opus | opus |
+| issue-linker | `comprehensive-review:issue-linker` | haiku | haiku |
 | dependency-check | `skills/comprehensive-review/scripts/run-cve-check.sh` (script, not agent) | n/a | n/a |
 
 **TIER=tiny model overrides** — when TIER=tiny was computed in Phase 0 step 7, apply these overrides on top of the model table. Overrides only apply at TIER=tiny; at TIER=small/medium the model table governs unchanged.
@@ -455,36 +455,36 @@ Rules: include directives as `KEY=value` on their own line at the start of the t
 
 **Always-run agents** (unless `--security-only` or `--summary-only` limits scope):
 
-- **pr-summarizer** (subagent_type: `pr-summarizer`, model: sonnet) — pass manifest, commit log, project context. Small diffs: also full diff inline.
+- **pr-summarizer** (subagent_type: `comprehensive-review:pr-summarizer`, model: sonnet) — pass manifest, commit log, project context. Small diffs: also full diff inline.
   If `--diagrams` was passed (and not `--quick`): include `DIAGRAMS=true` in the task description. Otherwise: include `DIAGRAMS=false`.
   **TIER=tiny:** use haiku instead of sonnet; pass only diff + PR title (drop manifest, commit log, project context).
 - **code-reviewer** (subagent_type: `pr-review-toolkit:code-reviewer`, model: sonnet) — always pass the full diff.
 
 **Full-run-only agents** (skipped with `--quick`):
 
-- **architecture-reviewer** (subagent_type: `architecture-reviewer`, model: opus) — pass manifest, FILE_DIGEST (from Phase 0 step 4), commit log, project context. Small diffs: also full diff inline.
+- **architecture-reviewer** (subagent_type: `comprehensive-review:architecture-reviewer`, model: opus) — pass manifest, FILE_DIGEST (from Phase 0 step 4), commit log, project context. Small diffs: also full diff inline.
   If PRIOR_REVIEW_CONTEXT is non-empty, append it after project context with the heading "Prior review history (for pattern context):".
   If RELATED_FILES is non-empty, include it in the task description (see directive table above).
   If LANGUAGE_PROFILES is non-empty, include it in the task description under the heading `LANGUAGE_PROFILES:`.
   If `--depth deep`: also include `EXTENDED_THINKING=true` in the task description.
   Always include in the task description: `"Tool budget: prefer batching parallel Read/Grep calls. Stop after 25 total tool calls or when you have enough evidence — do not re-read files you have already inspected."`
   **TIER=tiny:** skip unless ARCH_PROMOTED=true. When promoted, pass diff inline + RELATED_FILES only — drop FILE_DIGEST, commit log, project context, and PRIOR_REVIEW_CONTEXT.
-- **security-reviewer** (subagent_type: `security-reviewer`, model: opus) — pass manifest, FILE_DIGEST (from Phase 0 step 4), commit log, detected languages, project context. Small diffs: also full diff inline.
+- **security-reviewer** (subagent_type: `comprehensive-review:security-reviewer`, model: opus) — pass manifest, FILE_DIGEST (from Phase 0 step 4), commit log, detected languages, project context. Small diffs: also full diff inline.
   If PRIOR_REVIEW_CONTEXT is non-empty, append it after project context with the heading "Prior review history (for pattern context):".
   If RELATED_FILES is non-empty, include it in the task description (see directive table above).
   If LANGUAGE_PROFILES is non-empty, include it in the task description under the heading `LANGUAGE_PROFILES:`.
   If `--depth deep`: also include `EXTENDED_THINKING=true` in the task description.
   Always include in the task description: `"Tool budget: prefer batching parallel Bash/Read calls. Stop after 25 total tool calls or when you have enough evidence — do not re-read files you have already inspected."`
   **TIER=tiny:** skip unless SECURITY_PROMOTED=true. When promoted, pass diff inline + RELATED_FILES only — drop FILE_DIGEST, commit log, project context, and PRIOR_REVIEW_CONTEXT.
-- **adversarial-general** (subagent_type: `adversarial-general`, model: opus) — pass manifest, commit log, project context. Small diffs: also full diff inline. Medium/large: agent reads files via `git diff <base>...HEAD -- <file>`.
+- **adversarial-general** (subagent_type: `comprehensive-review:adversarial-general`, model: opus) — pass manifest, commit log, project context. Small diffs: also full diff inline. Medium/large: agent reads files via `git diff <base>...HEAD -- <file>`.
   If LANGUAGE_PROFILES is non-empty, include it in the task description under the heading `LANGUAGE_PROFILES:`.
   **TIER=tiny:** skip unconditionally. `--quick`: skip.
-- **blind-hunter** (subagent_type: `blind-hunter`, model: sonnet if depth=normal or **opus** if depth=deep) — **ZERO CONTEXT CONSTRAINT: pass ONLY the diff. No manifest, no project context, no commit log.**
+- **blind-hunter** (subagent_type: `comprehensive-review:blind-hunter`, model: sonnet if depth=normal or **opus** if depth=deep) — **ZERO CONTEXT CONSTRAINT: pass ONLY the diff. No manifest, no project context, no commit log.**
   Small diffs: full diff inline only.
   Medium/large (non-`--pr`): base branch name + plain file list from `git diff --name-only` (NOT the categorized manifest). Agent reads files via `git diff <base>...HEAD -- <file>`.
   Medium/large (`--pr` mode): `BLIND_DIFF_FILE=$(mktemp /tmp/cr-diff-blind-XXXXXXXX.txt) && git -C "$WORKTREE_PATH" diff <base>...HEAD > "$BLIND_DIFF_FILE"`, passes `$BLIND_DIFF_FILE` inline (agent has no worktree knowledge). Track for Phase 5 cleanup.
   **TIER=tiny:** skip unconditionally. `--depth deep` does not override this skip.
-- **edge-case-hunter** (subagent_type: `edge-case-hunter`, model: sonnet if depth=normal or **opus** if depth=deep) — pass manifest, commit log, project context. Small diffs: also full diff inline.
+- **edge-case-hunter** (subagent_type: `comprehensive-review:edge-case-hunter`, model: sonnet if depth=normal or **opus** if depth=deep) — pass manifest, commit log, project context. Small diffs: also full diff inline.
   If LANGUAGE_PROFILES is non-empty, include it in the task description under the heading `LANGUAGE_PROFILES:`.
   Has full codebase read access for surrounding context.
   **TIER=tiny:** skip unconditionally. `--depth deep` does not override this skip.
@@ -507,7 +507,7 @@ The grep checks the aggregate diff as a boolean — if it matches anywhere, the 
   **TIER=tiny:** skip.
 - **type-design-analyzer** (subagent_type: `pr-review-toolkit:type-design-analyzer`, model: sonnet) — trigger: type definitions (`type ... struct`, `interface `, `class `, `enum `) in the diff. Pass the full diff when triggered.
   **TIER=tiny:** skip.
-- **issue-linker** (subagent_type: `issue-linker`, model: haiku) — pass commit log, branch name, manifest, repo slug, and PROVIDER value. Skip in `--quick` and `--pr` modes, and when `--no-post`/`--local` was **explicitly** passed (not the default no-post behavior). Also skipped when PROVIDER is not `github` (agent returns NONE for non-GitHub providers).
+- **issue-linker** (subagent_type: `comprehensive-review:issue-linker`, model: haiku) — pass commit log, branch name, manifest, repo slug, and PROVIDER value. Skip in `--quick` and `--pr` modes, and when `--no-post`/`--local` was **explicitly** passed (not the default no-post behavior). Also skipped when PROVIDER is not `github` (agent returns NONE for non-GitHub providers).
 
 Track skipped agents and reasons for Phase 5. Launch all applicable agents simultaneously.
 
@@ -615,7 +615,7 @@ After all Phase 1 agents complete and Phase 1b finishes, run Phase 1c if applica
 - `--depth deep` was passed
 - `CVE_JSON` is non-empty (Phase 1b found vulnerabilities)
 
-When running: launch a single Opus agent (subagent_type: `security-reviewer`, model: `opus`) to annotate each CVE finding with a `reachability` tag without dropping or modifying any findings. Pass `CVE_JSON` and the diff of the changed manifest files. Task description:
+When running: launch a single Opus agent (subagent_type: `comprehensive-review:security-reviewer`, model: `opus`) to annotate each CVE finding with a `reachability` tag without dropping or modifying any findings. Pass `CVE_JSON` and the diff of the changed manifest files. Task description:
 
 > "You are a dependency security analyst. For each CVE finding in the JSON array below, determine whether the vulnerable package is actually reachable in this diff — i.e., is it used directly in changed code, or is it only a dev dependency, or is it a transitive dependency with no import visible in the diff? Return the same JSON array with one additional field per entry: `reachability` (string, one of: `reachable` | `dev-only` | `transitive-only` | `unknown`). Never drop findings. Never change any existing field. Only add the `reachability` field."
 


### PR DESCRIPTION
## Summary

Fixes #63. When comprehensive-review is installed via the marketplace (the README-recommended path), Claude Code registers every owned agent under the `comprehensive-review:` plugin namespace. The previous SKILL.md instructed the orchestrator to use bare names (`pr-summarizer`), causing every owned-agent spawn to fail with `Agent type 'pr-summarizer' not found` unless the model improvised a prefix on retry.

- **Root cause:** two install paths produced divergent namespace registrations — `install.sh` copied agents flat into `~/.claude/agents/<name>.md` (registered bare), while plugin install registers them as `comprehensive-review:<name>`. SKILL.md only matched the flat/bare form.
- **Fix:** SKILL.md now uses `comprehensive-review:<name>` for all owned agents, matching plugin install. `install.sh` rewritten to produce a plugin-shaped tree under `~/.claude/plugins/cache/tag1consulting-local/comprehensive-review/<version>/` so local dogfood exercises the same namespace as production.

## Changes

- `skills/comprehensive-review/SKILL.md` — rewrite CRITICAL namespace rule; update all 7 table rows and 8 spawn call sites to `comprehensive-review:<name>`; use glob pattern in fallback path chains (language-profiles, suppressions.json, scripts/) to support any install version slug
- `install.sh` — rewrite to lay down plugin tree + register in `installed_plugins.json` via `jq` upsert; local dogfood now matches marketplace namespace
- `.claude-plugin/plugin.json` — bump version to 1.6.1
- `CLAUDE.md`, `README.md` — update install/uninstall docs to reflect new plugin-tree layout

## Test plan

- [x] `./install.sh --local` completes successfully; `~/.claude/plugins/cache/tag1consulting-local/comprehensive-review/local/` exists with `.claude-plugin/plugin.json`, `agents/`, `skills/comprehensive-review/`
- [x] `installed_plugins.json` has `comprehensive-review@tag1consulting` entry pointing to the local path
- [x] Re-running `./install.sh --local` stays idempotent (entry count remains 1)
- [x] After restarting Claude Code: `/comprehensive-review --quick` succeeds with no `Agent type not found` errors (exercises `pr-summarizer`)
- [ ] After restarting Claude Code: `/comprehensive-review` full run on a medium PR — all seven owned agents (pr-summarizer, architecture-reviewer, security-reviewer, blind-hunter, edge-case-hunter, adversarial-general, issue-linker) spawn cleanly under their `comprehensive-review:` namespace
- [x] Marketplace install (`/plugins install comprehensive-review@tag1consulting` pointing at this tag) continues to work after merge + tag — tagged v1.6.1, marketplace.json updated