### PR TITLE
feat: add Serena MCP project configuration and onboarding memories

### DIFF
--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/memories/conventions.md
+++ b/.serena/memories/conventions.md
@@ -1,0 +1,32 @@
+# Conventions
+
+## Markdown / agent files
+- Agent files define scope + output format; coordination is in `SKILL.md` only.
+- Every custom agent must emit a trailing ` ```json-findings ` block with fields: `severity`, `confidence` (0–100), `file`, `line`, `finding`, `remediation`, `source`.
+- `GOVERNANCE.md` is the single place for governance directives shared across all agents. Do not duplicate directives into individual agent prompts.
+- `blind-hunter` receives ZERO project context — only the raw diff or plain file list. Enforce this invariant when editing `SKILL.md`.
+- BMAD attribution (`blind-hunter`, `edge-case-hunter`, `adversarial-general`) must be preserved.
+
+## SKILL.md structure
+- Phases 0–5; flag parse block in Phase 0; mode table in Phase 1.
+- When adding a flag: update Phase 0 parse block, Phase 1 mode table, `README.md` flags table, `HELP.md`.
+- When adding an agent: update agent roster table in `README.md`, Phase 1 launch conditions, severity normalization table in `SKILL.md`.
+
+## Language profiles
+- One file per language: `skills/comprehensive-review/language-profiles/<lang>.md`
+- Filename (lowercased) must match extension-based language detection in `SKILL.md` Phase 0.
+- Do NOT put per-language guidance directly in agent prompts.
+
+## Suppressions
+- Global rules in `suppressions.json`; per-repo overrides in `.claude/comprehensive-review/suppressions.json` (merged via `jq -s 'add'`).
+- Do not add project-specific rules to the global file.
+
+## Secrets
+- Replace all real secret values with `<secret-redacted>` before any external posting.
+- Phase 2 step 2f runs a hardcoded-pattern redaction pass in `SKILL.md` as defense-in-depth.
+
+## Git / branching
+- Never commit to `main` directly.
+- Feature/fix work goes on branches with worktrees created outside the repo path.
+- Commit messages include `Co-Authored-By: Claude <noreply@anthropic.com>` for AI-assisted work.
+- No "Generated with Claude Code" in PR descriptions, issues, or comments.

--- a/.serena/memories/core.md
+++ b/.serena/memories/core.md
@@ -1,0 +1,45 @@
+# Core — claude-comprehensive-review
+
+Claude Code plugin distributing the `/comprehensive-review` skill and 7 custom agents. Pure markdown — no build system, no compiled artifacts. Distributed via the `tag1consulting` plugin marketplace.
+
+## Source map
+
+```
+.claude-plugin/plugin.json          plugin manifest (name, version, author)
+skills/comprehensive-review/
+  SKILL.md                          orchestrator: Phases 0–5, all workflow logic
+  GOVERNANCE.md                     shared directives inlined into every agent's task
+  HELP.md                           user-facing flag reference
+  SEVERITY.md                       severity normalization + confidence scale
+  suppressions.json                 global suppression rules
+  language-profiles/                per-language review context (*.md, one per lang)
+  scripts/
+    run-cve-check.sh                OSV.dev CVE check (Phase 1b)
+    run-shellcheck.sh / run-semgrep.sh / run-trufflehog.sh / run-ruff.sh
+    run-golangci-lint.sh / run-checkov.sh   optional static analyzers
+agents/
+  pr-summarizer.md                  Block A generation
+  issue-linker.md                   issue cross-referencing (GitHub only)
+  security-reviewer.md              OWASP-class security analysis (Opus)
+  architecture-reviewer.md          design-pattern / coupling analysis (Opus)
+  blind-hunter.md                   context-free "fresh eyes" review (Sonnet)
+  edge-case-hunter.md               boundary-condition path tracing (Sonnet)
+  adversarial-general.md            holistic completeness/operational review (Opus)
+tests/
+  *.bats                            bats test suite (54 tests, bash/jq required)
+  fixtures/                         test input fixtures
+examples/
+  claude-security-guidance.example.md   copy-and-fill security policy template
+.serena/                            Serena project config + memories
+```
+
+## Key invariants
+
+- No build step — all deliverables are markdown files.
+- External dependency: `pr-review-toolkit` agents (not in this repo).
+- Optional dependency: `security-guidance` plugin (ambient hook-based security review).
+- `SKILL.md` is the single source of truth for workflow logic and phase ordering.
+- Agent files define scope boundaries; coordination lives entirely in `SKILL.md`.
+- `README.md` and `CLAUDE.md` must stay in sync with `SKILL.md` flag tables and agent roster.
+
+See `mem:tech_stack`, `mem:conventions`, `mem:suggested_commands`, `mem:task_completion`.

--- a/.serena/memories/memory_maintenance.md
+++ b/.serena/memories/memory_maintenance.md
@@ -1,0 +1,33 @@
+# Memory Maintenance
+
+## Discovery Model
+
+- Core principle: progressive discovery through references, building a graph of memories.
+- Initially, agents are provided with the list of all memories (names only).
+- Agents should read `mem:core` as the top-level entry point (graph root).
+  This memory should contain references to other memories covering major project domains.
+  The referenced memories shall, in turn, shall contain references to even more specific memories, and so on.
+  The depth of the graph shall depend on the project complexity.
+- Use topics/folders to group related memories in order to make the content structure explicit.
+  Folders can mirror project structure (e.g. modules like frontend/backend) or topics like debugging, architecture, etc.
+- Memory references must use a mem: prefix inside backticks, e.g. `mem:frontend/core`.
+  The surrounding text should clearly indicate when to read the memory/which content to expect.
+  The text should provide more precise guidance than the memory name alone, 
+  i.e. avoid a reference like "frontend debugging: `mem:frontend/debugging` and instead make clear which aspects of frontend debugging are covered.
+- Memories themselves should not contain information about when to read them; this is the responsibility of the referring memory.
+
+## Style
+
+Dense agent notes, not prose docs. Prefer invariants, terse bullets. 
+Avoid obvious context, rationale, and examples unless they prevent likely mistakes. 
+Keep guidance durable and generalizable, not task-local.
+
+## Add/update threshold
+
+Add or update memories only with stable, non-obvious project conventions that avoid complex rediscovery in the future.
+Do not add: quick-read facts; generic language/framework knowledge; one-off task notes; volatile line-level details; behavior likely to change soon.
+
+## Maintenance Actions
+
+- Renaming memories: References are updated automatically if handled via Serena's memory rename tool.
+- Checking for stale memories (e.g. after deletion): Call `serena memories check` for a report.

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -1,0 +1,25 @@
+# Suggested Commands
+
+## Tests
+```bash
+bats tests/*.bats          # run full test suite (requires bats + jq)
+bats tests/run_cve_check.bats   # run just CVE check tests
+```
+
+## Installation (end users and contributors)
+```bash
+# Install or reinstall from marketplace (after tagging a pre-release or merging to main)
+/plugins install comprehensive-review@tag1consulting
+```
+No `install.sh` — removed; marketplace install is the only supported path.
+
+## Linting scripts (manual, for changed files)
+```bash
+shellcheck skills/comprehensive-review/scripts/*.sh
+```
+
+## Release workflow
+1. Update `version` in `.claude-plugin/plugin.json`
+2. Update plugin entry version in `tag1consulting/claude-plugins` marketplace repo
+3. Tag this repo `v<version>`
+4. Always run `/comprehensive-review` before creating the release PR

--- a/.serena/memories/task_completion.md
+++ b/.serena/memories/task_completion.md
@@ -1,0 +1,10 @@
+# Task Completion
+
+When a coding task is done:
+
+1. **Run tests**: `bats tests/*.bats` — must pass (requires `bats` + `jq`)
+2. **Lint shell scripts** (if `scripts/` changed): `shellcheck skills/comprehensive-review/scripts/*.sh`
+3. **Check docs sync**: if `SKILL.md` flags/agents changed, verify `README.md` and `HELP.md` are in sync
+4. **Before any release PR**: run `/comprehensive-review` on the branch first (project policy)
+
+No formatter, no type checker, no build step — the test suite + shellcheck are the full quality gate for code changes. Markdown-only changes have no automated quality gate.

--- a/.serena/memories/tech_stack.md
+++ b/.serena/memories/tech_stack.md
@@ -1,0 +1,24 @@
+# Tech Stack
+
+## Language & runtime
+- **Primary language**: Bash (shell scripts in `scripts/`; bats test suite)
+- **Content format**: Markdown (all agents, skills, docs — the majority of the repo)
+- **No compiled code, no build pipeline**
+
+## Test framework
+- `bats` (Bash Automated Testing System) — `tests/*.bats`
+- Requires: `bats`, `jq`
+- 54 tests across 4 test files
+
+## Distribution
+- Claude Code plugin marketplace (`tag1consulting` org)
+- Plugin manifest: `.claude-plugin/plugin.json`
+- Version format: semver without `v` prefix in `plugin.json`; git tags use `v` prefix (e.g., `v1.10.0`)
+
+## External tools used at review runtime (all optional/opportunistic)
+- `shellcheck`, `semgrep`, `trufflehog`, `ruff`, `golangci-lint`, `checkov` — skip silently if absent
+- `jq` — required by CVE check script and bats tests
+- `curl` — used by CVE check (OSV.dev API) and claude-mem integration
+
+## Language servers (Serena)
+- Configured for `bash` only (`project.yml`)

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,133 @@
+# the name by which the project can be referenced within Serena
+project_name: "claude-comprehensive-review"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   svelte              swift               systemverilog       terraform           toml
+#   typescript          typescript_vts      vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- bash
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+fixed_tools: []
+
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+default_modes:
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []


### PR DESCRIPTION
## Summary

- Adds `.serena/project.yml` — Serena MCP project config (bash language server, utf-8 encoding)
- Adds `.serena/memories/` — 6 architectural knowledge files covering core source map, tech stack, suggested commands, code conventions, and task-completion checklist
- Adds `.serena/.gitignore` — excludes ephemeral cache and local overrides from git

## Why

[Serena MCP](https://github.com/oraios/serena) provides semantic code intelligence (LSP-backed symbol search, reference finding, symbol-level editing) that is significantly more token-efficient than file-level reads. The memories give any Claude session with Serena immediate architectural context without re-exploring the codebase from scratch.

## What's committed vs. excluded

| Path | Committed | Reason |
|---|---|---|
| `.serena/project.yml` | ✅ | Shared LSP config |
| `.serena/memories/*.md` | ✅ | Shared architectural knowledge |
| `.serena/.gitignore` | ✅ | Ensures cache/ and local overrides stay excluded |
| `.serena/cache/` | ❌ gitignored | Machine-specific LSP index |
| `.serena/project.local.yml` | ❌ gitignored | Per-user local overrides |

## Test plan

- [ ] Verify `.serena/cache/` and `.serena/project.local.yml` are not tracked (`git status` shows clean after Serena runs)
- [ ] Confirm Serena loads project memories on next session start