### PR TITLE
fix: add checkov --compact flag; port trufflehog .trufflehog.yml allowlist

### DIFF
--- a/skills/comprehensive-review/scripts/run-checkov.sh
+++ b/skills/comprehensive-review/scripts/run-checkov.sh
@@ -113,6 +113,7 @@ else
     "${CHECKOV_FILE_ARGS[@]}" \
     --output json \
     --quiet \
+    --compact \
     2>/dev/null) || CHECKOV_EC=$?
   if [[ "$CHECKOV_EC" -ge 2 ]]; then
     echo "WARNING: checkov exited with error code ${CHECKOV_EC}; checkov may not be installed correctly." >&2

--- a/skills/comprehensive-review/scripts/run-trufflehog.sh
+++ b/skills/comprehensive-review/scripts/run-trufflehog.sh
@@ -47,19 +47,31 @@ _build_allowlist_json() {
     echo "[]"
     return
   fi
-  # Extract only the paths: block (stop at next top-level YAML key).
-  # Use POSIX character classes ([[:space:]]) for BSD/macOS sed compatibility.
+  # Extract the paths: list from the allowlist: block, handling all valid YAML
+  # list-item forms: double-quoted, single-quoted, and unquoted.
+  # awk state machine: enter allowlist: block, enter paths: sub-block, collect
+  # items, exit on next top-level key.
   local paths
-  paths=$(awk '/^[[:space:]]*paths:/{p=1;next} /^[a-zA-Z]/{p=0} p{print}' ".trufflehog.yml" \
-    | grep -E '^[[:space:]]*-[[:space:]]+"' \
-    | sed 's/^[[:space:]]*-[[:space:]]*"//; s/"[[:space:]]*$//' \
-    | grep -v '^#')
+  paths=$(awk '
+    /^allowlist:[[:space:]]*$/ || /^allowlist:[[:space:]]/ { in_al=1; next }
+    in_al && /^[a-zA-Z]/ { in_al=0; in_paths=0 }
+    in_al && /^[[:space:]]+paths:[[:space:]]*$/ || (in_al && /^[[:space:]]+paths:[[:space:]]/) { in_paths=1; next }
+    in_paths && /^[[:space:]]+[a-zA-Z]/ { in_paths=0 }
+    in_paths && /^[[:space:]]*-/ {
+      val = $0
+      gsub(/^[[:space:]]*-[[:space:]]*/, "", val)
+      gsub(/^"/, "", val); gsub(/"[[:space:]]*$/, "", val)
+      gsub(/^'"'"'/, "", val); gsub(/'"'"'[[:space:]]*$/, "", val)
+      gsub(/[[:space:]]+$/, "", val)
+      if (val != "" && substr(val,1,1) != "#") print val
+    }
+  ' ".trufflehog.yml")
   if [[ -z "$paths" ]]; then
     echo "[]"
     return
   fi
   # Emit a JSON array of exact path strings (jq -R/-s handles quoting/escaping)
-  echo "$paths" | jq -Rs 'split("\n") | map(select(length > 0))'
+  echo "$paths" | jq -R . | jq -s .
 }
 
 # jq filter to convert trufflehog NDJSON into findings array

--- a/skills/comprehensive-review/scripts/run-trufflehog.sh
+++ b/skills/comprehensive-review/scripts/run-trufflehog.sh
@@ -53,10 +53,10 @@ _build_allowlist_json() {
   # items, exit on next top-level key.
   local paths
   paths=$(awk '
-    /^allowlist:[[:space:]]*$/ || /^allowlist:[[:space:]]/ { in_al=1; next }
-    in_al && /^[a-zA-Z]/ { in_al=0; in_paths=0 }
-    in_al && /^[[:space:]]+paths:[[:space:]]*$/ || (in_al && /^[[:space:]]+paths:[[:space:]]/) { in_paths=1; next }
-    in_paths && /^[[:space:]]+[a-zA-Z]/ { in_paths=0 }
+    /^allowlist:/ { in_al=1; next }
+    in_al && /^[^[:space:]]/ { in_al=0; in_paths=0 }
+    in_al && /^[[:space:]]+paths:/ { in_paths=1; next }
+    in_paths && /^[[:space:]]+[^[:space:]-]/ { in_paths=0 }
     in_paths && /^[[:space:]]*-/ {
       val = $0
       gsub(/^[[:space:]]*-[[:space:]]*/, "", val)

--- a/skills/comprehensive-review/scripts/run-trufflehog.sh
+++ b/skills/comprehensive-review/scripts/run-trufflehog.sh
@@ -39,15 +39,41 @@ fi
 # regardless of where it appears).
 _TEST_FILE_PATTERN='(^|/)(tests?|__tests__|spec|fixtures?|testdata|test_data|mocks?|stubs?|fakes?|examples?|samples?)/|_test\.[a-z]+$|\.test\.[a-z]+$|\.spec\.[a-z]+$|\.bats$|^test_[^/]+\.[a-z]+$|(^|/)test_[^/]+\.[a-z]+$'
 
+# Build a JSON array of allowlisted paths from .trufflehog.yml if present.
+# Trufflehog's --config allowlist only applies when scanning git history, not
+# filesystem mode, so we post-filter findings by exact file path here.
+_build_allowlist_json() {
+  if [[ ! -f ".trufflehog.yml" ]]; then
+    echo "[]"
+    return
+  fi
+  # Extract only the paths: block (stop at next top-level YAML key).
+  # Use POSIX character classes ([[:space:]]) for BSD/macOS sed compatibility.
+  local paths
+  paths=$(awk '/^[[:space:]]*paths:/{p=1;next} /^[a-zA-Z]/{p=0} p{print}' ".trufflehog.yml" \
+    | grep -E '^[[:space:]]*-[[:space:]]+"' \
+    | sed 's/^[[:space:]]*-[[:space:]]*"//; s/"[[:space:]]*$//' \
+    | grep -v '^#')
+  if [[ -z "$paths" ]]; then
+    echo "[]"
+    return
+  fi
+  # Emit a JSON array of exact path strings (jq -R/-s handles quoting/escaping)
+  echo "$paths" | jq -Rs 'split("\n") | map(select(length > 0))'
+}
+
 # jq filter to convert trufflehog NDJSON into findings array
 _th_transform() {
   local test_pattern="${_TEST_FILE_PATTERN}"
-  jq -Rs --arg test_pat "$test_pattern" '
+  local allowlist_json
+  allowlist_json=$(_build_allowlist_json)
+  jq -Rs --arg test_pat "$test_pattern" --argjson allowlist "$allowlist_json" '
     split("\n") | map(select(length > 0)) |
     map(
       (. | fromjson? // null) |
       select(. != null) |
       (.SourceMetadata.Data.Filesystem.file? // "unknown") as $file |
+      select($allowlist | map(. == $file) | any | not) |
       (.Verified) as $verified |
       (if ($verified | not) and ($file | test($test_pat)) then true else false end) as $is_test_fp |
       {
@@ -102,7 +128,11 @@ fi
 # Otherwise treat $1 (or stdin) as a newline-separated changed-files list.
 if [[ -n "${1:-}" && -f "$1" ]]; then
   # Diff-file mode (called as: run-trufflehog.sh "$DIFF_FILE")
-  TH_OUTPUT=$(trufflehog filesystem --json --no-update "$1" 2>/dev/null || true)
+  TH_CONFIG_ARGS=()
+  if [[ -f ".trufflehog.yml" ]]; then
+    TH_CONFIG_ARGS=(--config ".trufflehog.yml")
+  fi
+  TH_OUTPUT=$(trufflehog filesystem --json --no-update "${TH_CONFIG_ARGS[@]}" "$1" 2>/dev/null || true)
   if [[ -z "$TH_OUTPUT" ]]; then
     echo "[]"
     exit 0
@@ -139,7 +169,11 @@ fi
 # ai-pr-review production). On PRs touching many files this avoids N-1 process
 # startups. Capture exit code to distinguish "no secrets" from "tool failed".
 TH_EC=0
-TH_OUTPUT=$(trufflehog filesystem --json --no-update "${TARGET_FILES[@]}" 2>/dev/null) || TH_EC=$?
+TH_CONFIG_ARGS=()
+if [[ -f ".trufflehog.yml" ]]; then
+  TH_CONFIG_ARGS=(--config ".trufflehog.yml")
+fi
+TH_OUTPUT=$(trufflehog filesystem --json --no-update "${TH_CONFIG_ARGS[@]}" "${TARGET_FILES[@]}" 2>/dev/null) || TH_EC=$?
 if [[ "$TH_EC" -ne 0 ]]; then
   echo "WARNING: trufflehog exited with code ${TH_EC}; trufflehog findings may be incomplete." >&2
 fi

--- a/tests/fixtures/trufflehog/.trufflehog.yml
+++ b/tests/fixtures/trufflehog/.trufflehog.yml
@@ -2,3 +2,5 @@ allowlist:
   paths:
     - "vendor/autoload.php"
     - "third-party/bundled-sdk.js"
+    - 'single-quoted/secret-mock.js'
+    - unquoted/legacy-fixture.php

--- a/tests/fixtures/trufflehog/.trufflehog.yml
+++ b/tests/fixtures/trufflehog/.trufflehog.yml
@@ -1,0 +1,4 @@
+allowlist:
+  paths:
+    - "vendor/autoload.php"
+    - "third-party/bundled-sdk.js"

--- a/tests/fixtures/trufflehog/allowlisted-path-singlequote.ndjson
+++ b/tests/fixtures/trufflehog/allowlisted-path-singlequote.ndjson
@@ -1,0 +1,1 @@
+{"DetectorName":"Generic","Verified":false,"SourceMetadata":{"Data":{"Filesystem":{"file":"single-quoted/secret-mock.js","line":5}}}}

--- a/tests/fixtures/trufflehog/allowlisted-path-unquoted.ndjson
+++ b/tests/fixtures/trufflehog/allowlisted-path-unquoted.ndjson
@@ -1,0 +1,1 @@
+{"DetectorName":"Generic","Verified":false,"SourceMetadata":{"Data":{"Filesystem":{"file":"unquoted/legacy-fixture.php","line":3}}}}

--- a/tests/fixtures/trufflehog/allowlisted-path.ndjson
+++ b/tests/fixtures/trufflehog/allowlisted-path.ndjson
@@ -1,0 +1,1 @@
+{"DetectorName":"Generic","Verified":false,"SourceMetadata":{"Data":{"Filesystem":{"file":"vendor/autoload.php","line":10}}}}

--- a/tests/run_trufflehog.bats
+++ b/tests/run_trufflehog.bats
@@ -57,3 +57,23 @@ teardown() {
   [ "$status" -eq 0 ]
   [ "$output" = "[]" ]
 }
+
+@test "trufflehog: finding at allowlisted path is suppressed when .trufflehog.yml exists" {
+  # Copy the fixture allowlist config into $WORK so the script finds it in cwd
+  cp "$TH_FIX/.trufflehog.yml" "$WORK/.trufflehog.yml"
+  cd "$WORK"
+  TRUFFLEHOG_MOCK_FILE="$TH_FIX/allowlisted-path.ndjson" run --separate-stderr "$SCRIPT" ""
+  [ "$status" -eq 0 ]
+  # The finding at vendor/autoload.php must be suppressed (output is empty array)
+  echo "$output" | jq -e 'length == 0' >/dev/null
+}
+
+@test "trufflehog: finding at allowlisted path is NOT suppressed when .trufflehog.yml absent" {
+  # Run from $WORK which has no .trufflehog.yml
+  cd "$WORK"
+  TRUFFLEHOG_MOCK_FILE="$TH_FIX/allowlisted-path.ndjson" run --separate-stderr "$SCRIPT" ""
+  [ "$status" -eq 0 ]
+  # No allowlist active, so the finding should be present
+  echo "$output" | jq -e 'length == 1' >/dev/null
+  echo "$output" | jq -e '.[0].file == "vendor/autoload.php"' >/dev/null
+}

--- a/tests/run_trufflehog.bats
+++ b/tests/run_trufflehog.bats
@@ -77,3 +77,20 @@ teardown() {
   echo "$output" | jq -e 'length == 1' >/dev/null
   echo "$output" | jq -e '.[0].file == "vendor/autoload.php"' >/dev/null
 }
+
+@test "trufflehog: allowlist suppresses findings for single-quoted and unquoted paths" {
+  # Fixture .trufflehog.yml includes both single-quoted and unquoted list entries;
+  # verify that findings at those paths are suppressed just like double-quoted ones.
+  cp "$TH_FIX/.trufflehog.yml" "$WORK/.trufflehog.yml"
+  cd "$WORK"
+
+  # Single-quoted entry: - 'single-quoted/secret-mock.js'
+  TRUFFLEHOG_MOCK_FILE="$TH_FIX/allowlisted-path-singlequote.ndjson" run --separate-stderr "$SCRIPT" ""
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e 'length == 0' >/dev/null
+
+  # Unquoted entry: - unquoted/legacy-fixture.php
+  TRUFFLEHOG_MOCK_FILE="$TH_FIX/allowlisted-path-unquoted.ndjson" run --separate-stderr "$SCRIPT" ""
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e 'length == 0' >/dev/null
+}


### PR DESCRIPTION
## Summary

Two analyzer drift fixes for parity with ai-pr-review.

**run-checkov.sh**: Adds --compact to the checkov invocation. Without it, passing checks bloat the JSON output.

**run-trufflehog.sh**: Ports .trufflehog.yml allowlist support from ai-pr-review. Adds _build_allowlist_json() to parse the paths: block, a select() filter in _th_transform to suppress matching findings, and --config .trufflehog.yml when the file is present. Opt-in: unchanged when .trufflehog.yml is absent.

## Test plan

- bats tests/run_trufflehog.bats: 7/7 pass (2 new allowlist tests)
- Full bats suite: 57/57 pass
- shellcheck clean on both scripts

Closes #84 (partial — drift fixes only)