### PR TITLE
chore: release v1.11.0 — 6 new analyzers + checkov/trufflehog fixes

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "comprehensive-review",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Comprehensive PR review using parallel specialized agents. Produces structured PR summaries and severity-ranked findings from 10+ agents.",
   "author": {
     "name": "Tag1 Consulting",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.0] - 2026-06-02
+
+### Added
+
+- **6 new static analyzers** (#86): Ported from `ai-pr-review` and wired into Phase 1b orchestration. All are opportunistic (silently skipped when the binary is absent) and use mock-file-based offline bats tests (no real binary invoked in CI).
+  - **`run-eslint.sh`** — JavaScript/TypeScript linting via ESLint. Triggers on `.js`, `.jsx`, `.ts`, `.tsx`, `.mjs`, `.cjs` files; skips silently when no ESLint config is found in the repo root (`GITHUB_WORKSPACE`). Detects `--no-warn-ignored` support via `--help` (not `--version`, which short-circuits arg parsing). Severity mapping: `error` → High, `warning` → Medium.
+  - **`run-hadolint.sh`** — Dockerfile linting. Triggers on `Dockerfile`, `Dockerfile.*`, and `*.dockerfile` variants. Severity mapping: `error` → High, `warning` → Medium, `info`/`style` → Low.
+  - **`run-kube-linter.sh`** — Kubernetes manifest linting. Triggers on `.yaml`, `.yml`, and `.json` files that contain `apiVersion:` and `kind:` fields (content-sniff guard avoids running on non-K8s YAML). All findings mapped to Medium.
+  - **`run-phpcs.sh`** — PHP CodeSniffer. Triggers on `.php` files. Uses `Drupal`/`DrupalPractice` standard when phpstan-drupal is available, falls back to `PSR12`. Remediation string uses the active standard (not hardcoded). Severity mapping: `error` → High, `warning` → Medium.
+  - **`run-phpstan.sh`** — PHP static analysis. Triggers on `.php`, `.module`, `.inc`, `.install`, `.theme` files. Vendor paths (`phpstan-drupal`, `autoload.php`) resolved relative to `GITHUB_WORKSPACE` (repo root) rather than script CWD. All findings mapped to High.
+  - **`run-tflint.sh`** — Terraform linting. Triggers on `.tf` and `.tfvars` files; runs per-directory, prepending the directory prefix to bare filenames in output. Captures exit code explicitly (`DIR_EC`) to distinguish violations-found (exit 1) from fatal config errors (exit >= 2). Severity mapping: `error` → High, `warning` → Medium, `notice` → Low.
+- **96 new bats tests** (#86): Mock-file-driven test suites for all 6 new analyzers, covering no-op paths, schema conformance, severity mapping, stdin support, and tool-absent behavior. Total test suite grows from 54 to 150.
+
+### Fixed
+
+- **`checkov --compact` flag** (#87): Added `--compact` to the `checkov` invocation in `run-checkov.sh`. Without it, passing checks bloat the JSON output significantly, slowing processing and inflating context.
+- **Trufflehog allowlist: single-quoted and unquoted YAML path entries no longer silently dropped** (#87): `_build_allowlist_json()` previously only extracted double-quoted path entries from `.trufflehog.yml`. Entries in YAML bare form (`- path/to/file`) or single-quoted form (`- 'path/to/file'`) were silently ignored, leaving findings at allowlisted paths unsuppressed. Awk state machine rewritten to handle all three forms. Block-termination patterns broadened from `/^[a-zA-Z]/` to `/^[^[:space:]]/` to correctly stop at top-level YAML keys starting with digits or underscores.
+
+---
+
 ## [1.10.0] - 2026-05-29
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository purpose
 
-This repo distributes a Claude Code skill (`/comprehensive-review`) and seven custom agents as a Claude Code plugin. The skill supports GitHub (including Enterprise), GitLab, and Bitbucket repositories. Deliverables are markdown files distributed via the `tag1consulting` plugin marketplace. The deterministic bash helpers have a bats test suite (`tests/*.bats`, 54 tests); run with `bats tests/*.bats` (requires `bats` and `jq`).
+This repo distributes a Claude Code skill (`/comprehensive-review`) and seven custom agents as a Claude Code plugin. The skill supports GitHub (including Enterprise), GitLab, and Bitbucket repositories. Deliverables are markdown files distributed via the `tag1consulting` plugin marketplace. The deterministic bash helpers have a bats test suite (`tests/*.bats`, 150 tests); run with `bats tests/*.bats` (requires `bats` and `jq`).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -319,8 +319,14 @@ In addition to LLM agents, the skill runs deterministic checks when relevant fil
 | **ruff** — Python linting | `.py` files changed | Yes | `ruff` |
 | **golangci-lint** — Go static analysis | `.go` files changed | Yes | `golangci-lint` |
 | **checkov** — IaC security scanning | `*.tf`, `*.tfvars`, `Dockerfile`, k8s YAML, CloudFormation, Azure ARM changed | Yes | `checkov` |
+| **eslint** — JavaScript/TypeScript linting | `.js`, `.jsx`, `.ts`, `.tsx`, `.mjs`, `.cjs` files changed; only runs when an ESLint config is present | No | `eslint` (via `npx` or `node_modules/.bin`) |
+| **hadolint** — Dockerfile linting | `Dockerfile`, `Dockerfile.*`, or `*.dockerfile` changed | No | `hadolint` |
+| **kube-linter** — Kubernetes manifest linting | `.yaml`, `.yml`, or `.json` files containing `apiVersion` and `kind` fields | No | `kube-linter` |
+| **phpcs** — PHP CodeSniffer | `.php` files changed; uses Drupal/DrupalPractice standard when available, falls back to PSR-12 | No | `phpcs` |
+| **phpstan** — PHP static analysis | `.php`, `.module`, `.inc`, `.install`, `.theme` files changed | No | `phpstan` |
+| **tflint** — Terraform linting | `.tf` or `.tfvars` files changed; runs per-directory | No | `tflint` |
 
-No API key required for any check. All static analyzers are **opportunistic** — if the binary is not installed, the check is silently skipped with no error. Install as needed: `brew install shellcheck`, `pip install semgrep ruff checkov`, `go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest`, [trufflehog releases](https://github.com/trufflesecurity/trufflehog/releases). Findings appear in Block B with the tool name as source (e.g., `[shellcheck]`, `[semgrep]`).
+No API key required for any check. All static analyzers are **opportunistic** — if the binary is not installed, the check is silently skipped with no error. Install as needed: `brew install shellcheck hadolint kube-linter tflint`, `pip install semgrep ruff checkov`, `go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest`, [trufflehog releases](https://github.com/trufflesecurity/trufflehog/releases), `npm install -g eslint`, `composer global require squizlabs/php_codesniffer phpstan/phpstan`. Findings appear in Block B with the tool name as source (e.g., `[shellcheck]`, `[eslint]`).
 
 ### `--quick` mode
 
@@ -536,7 +542,7 @@ brew install bats-core
 bats tests/*.bats
 ```
 
-Tests cover: `parse_go_mod` replace-directive ordering, TruffleHog invocation modes, gate evaluation logic, and golden orchestration contracts (SKILL.md structural integrity, PROVIDERS.md correctness, SEVERITY.md contract). All 54 tests are offline (no network, no Claude invocation).
+Tests cover: `parse_go_mod` replace-directive ordering, TruffleHog invocation modes (including allowlist suppression), gate evaluation logic, golden orchestration contracts (SKILL.md structural integrity, PROVIDERS.md correctness, SEVERITY.md contract), and all static analyzer scripts (eslint, hadolint, kube-linter, phpcs, phpstan, tflint). All 150 tests are offline (no network, no Claude invocation).
 
 ## Acknowledgments
 


### PR DESCRIPTION
## Summary

- Bump plugin version to `1.11.0`
- Add 6 new static analyzers ported from ai-pr-review (eslint, hadolint, kube-linter, phpcs, phpstan, tflint) — already merged via #86
- Fix checkov `--compact` flag and trufflehog allowlist handling for single-quoted/unquoted YAML paths — already merged via #87
- Update README static analyzers table and install instructions
- Update bats test count in README and CLAUDE.md (54 → 150)

## Test plan

- [x] `bats tests/*.bats` — all 150 tests pass
- [ ] Merge this PR
- [ ] Tag `v1.11.0` on main
- [ ] Bump `version` to `1.11.0` in `tag1consulting/claude-plugins` marketplace repo