### PR TITLE
chore: remove ai-pr-review git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule ".github/actions/ai-pr-review"]
-	path = .github/actions/ai-pr-review
-	url = https://github.com/tag1consulting/ai-pr-review.git


### PR DESCRIPTION
## Summary

- Removes the leftover `.gitmodules` file and `.github/actions/ai-pr-review` submodule entry
- The workflow was already migrated to `tag1consulting/ai-pr-review/container-action@main` in a prior commit; the submodule was never cleaned up after that migration
- No workflow logic changes — `.github/workflows/ai-pr-review.yml` is unchanged

## Test plan

- [ ] Confirm CI passes on this PR (workflow uses the container action, not the submodule)
- [ ] Confirm `.gitmodules` and `.github/actions/ai-pr-review` are absent after merge