### PR TITLE
chore: remove Mermaid sequence diagram feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ The orchestrator itself is governed by a separate "Orchestrator Governance" sect
 
 The skill produces two distinct output blocks with different audiences:
 
-- **Block A** (informational) — summary, walkthrough table, Mermaid diagrams (opt-in via `--diagrams`), related issues. Contains no findings.
+- **Block A** (informational) — summary, walkthrough table, related issues. Contains no findings.
 - **Block B** (findings) — severity-ranked issues from all agents. Always displayed in the terminal.
 
 Both blocks are always shown locally. What gets posted to the hosting provider depends on context:
@@ -237,7 +237,7 @@ agents/adversarial-general.md                                ← holistic comple
 - **`README.md` and `CLAUDE.md`** must stay in sync with `SKILL.md` — specifically the flags table, agent roster, and output structure sections.
 - When adding a new agent to the skill, add it to: the agent roster table in `README.md`, the Phase 1 launch conditions in `SKILL.md`, and the severity normalization table in `SKILL.md` if it uses a non-standard scale.
 - The `allowed-tools` frontmatter in `SKILL.md` controls which tools the orchestrator can use. When adding GitHub write operations, add the corresponding `mcp__github-pat__*` tool there.
-- When modifying `--quick` or `--diagrams` behavior, update the mode flag table in Phase 1 of `SKILL.md`, the flags section at the top of `SKILL.md`, the flags table in `README.md`, and `HELP.md`.
+- When modifying `--quick` behavior, update the mode flag table in Phase 1 of `SKILL.md`, the flags section at the top of `SKILL.md`, the flags table in `README.md`, and `HELP.md`.
 - When adding a new flag, update: the flags parse block in `SKILL.md` (Phase 0, L32–46 area), the mode table in `SKILL.md` (Phase 1 L242–250 area), the flags table in `README.md`, and `HELP.md`.
 - **`HELP.md`** is the reference documentation for all flags. Users can read it directly or via the README. Do not add a `--help` flag handler inside `SKILL.md` or a dedicated help skill — both approaches have been tried and failed (the LLM cannot reliably stop mid-document, `disable-model-invocation: true` suppresses all output, and a verbatim-output skill produces blank output in Claude Code).
 - **blind-hunter** has a unique context constraint: it must receive ONLY the diff or plain file list — no manifest, no project context, no commit log. If you change the context-passing strategy in `SKILL.md`, verify blind-hunter's constraint is still enforced. The agent file itself also instructs the agent to ignore any extra context it receives.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ When you run `/comprehensive-review` on a branch, it:
 1. Launches specialized review agents **in parallel**, using token-efficient context passing
 2. Normalizes and deduplicates their findings into a unified severity ranking
 3. Assembles two output blocks:
-   - **Block A (informational)** — Summary, file walkthrough table, Mermaid sequence diagrams (opt-in via `--diagrams`), effort estimate, related issues/PRs
+   - **Block A (informational)** — Summary, file walkthrough table, effort estimate, related issues/PRs
    - **Block B (findings)** — Critical/High/Medium/Low findings, architectural insights, security analysis, recommended actions
 4. Posts Block A and/or Block B to the hosting provider based on the flags and scenario (see [Posting behavior](#posting-behavior))
 
@@ -29,7 +29,6 @@ The `pr-review-toolkit` plugin provides excellent code-level agents (bug detecti
 | **Context-free "fresh eyes" review** | No | Yes (blind-hunter, Sonnet) |
 | **Mechanical boundary-condition tracing** | No | Yes (edge-case-hunter, Sonnet) |
 | **PR summary + walkthrough table** | No | Yes (pr-summarizer) |
-| **Mermaid sequence diagrams** | No | Yes (pr-summarizer, opt-in via `--diagrams`) |
 | **Related issue/PR discovery** | No | Yes (issue-linker) |
 | **Unified severity ranking** | Per-agent only | Normalized across all agents, deduplicated |
 | **Inline PR/MR review posting** | No | Yes (`--post-findings`, `--pr`) |
@@ -193,7 +192,6 @@ Run from any git repository, on the branch you want to review:
 | *(auto)* TIER=tiny | Automatically applied when the diff is under 50 lines AND ≤3 files. Routes pr-summarizer to Haiku; skips blind-hunter, edge-case-hunter, comment-analyzer, type-design-analyzer unconditionally; skips architecture-reviewer and security-reviewer unless triggered by infra/CI paths or auth/credential/dep-manifest paths respectively. Roughly 60–70% cheaper than `--quick` on tiny diffs (~$1 → ~$0.30). |
 | *(auto)* DOCS_ONLY | Automatically applied when all changed files are documentation/markdown/meta (no code or infra). Runs pr-summarizer + code-reviewer + triggered conditionals. Skips all Opus agents and blind/edge-case/comment/type agents. Phase 5 reports the reason. Overridden by `--depth deep`, `--quick`, `--security-only`, `--summary-only`. |
 | *(auto)* LOW_RISK_CONFIG | Automatically applied when the diff contains only config/YAML/TOML with no security-sensitive patterns and no dep manifests/CI files. Runs pr-summarizer + code-reviewer + deterministic checks. Skips specialist Opus agents and blind/edge-case agents. Phase 5 reports the reason. |
-| `--diagrams` | Include Mermaid sequence diagrams in Block A. Default is omitted (saves hundreds of output tokens). Always omitted in `--quick`. |
 | `--security-only` | Run security-reviewer + CVE check on changed dependency manifests only |
 | `--depth <tier>` | Agent depth: `normal` (default) or `deep`. In `deep` mode, blind-hunter and edge-case-hunter run on the `opus` alias, Opus agents use extended step-by-step reasoning, and a CVE reachability triage pass annotates which vulnerabilities are reachable in the diff. |
 | `--summary-only` | Run only the pr-summarizer agent |
@@ -293,7 +291,7 @@ Opus agents (`architecture-reviewer`, `security-reviewer`) use the `opus` alias,
 
 | Agent | Model | Purpose | When it runs | Context |
 |-------|-------|---------|--------------|---------|
-| **pr-summarizer** | Sonnet | Summary, walkthrough table, Mermaid diagrams (opt-in), effort score | Always | Manifest + selective reads ² |
+| **pr-summarizer** | Sonnet | Summary, walkthrough table, effort score | Always | Manifest + selective reads ² |
 | **code-reviewer** ¹ | Sonnet | Tactical bugs, style violations, project conventions | Always | Full diff |
 | **architecture-reviewer** | Opus | System design, coupling, API design, technical debt | Full run only | Manifest + selective reads ² |
 | **security-reviewer** | Opus | OWASP-class security analysis, language-specific checks | Full run only | Manifest + selective reads ² |
@@ -331,7 +329,7 @@ No API key required for any check. All static analyzers are **opportunistic** �
 ### `--quick` mode
 
 Skips: architecture-reviewer, security-reviewer, blind-hunter, edge-case-hunter, comment-analyzer, type-design-analyzer, issue-linker.
-Still runs: pr-summarizer (no diagrams), code-reviewer, triggered silent-failure-hunter / pr-test-analyzer, and the CVE check if manifest files changed.
+Still runs: pr-summarizer, code-reviewer, triggered silent-failure-hunter / pr-test-analyzer, and the CVE check if manifest files changed.
 
 ¹ From the `pr-review-toolkit@claude-plugins-official` plugin.
 ² For small diffs (under 300 lines), the full diff is passed inline instead.
@@ -439,7 +437,6 @@ PR/MR description (Block A only — no findings):
 ```
 ## Summary
 ## Walkthrough
-## Sequence Diagrams  (only with --diagrams)
 ## Related Issues & PRs
 ```
 

--- a/agents/pr-summarizer.md
+++ b/agents/pr-summarizer.md
@@ -2,9 +2,9 @@
 name: pr-summarizer
 description: |
   Generate a structured PR overview including a high-level summary, file-by-file
-  walkthrough table, Mermaid sequence diagrams of changed control flows, and a
-  review effort estimate. Called as part of the comprehensive-review skill. Its
-  output is used as the PR description when creating a new PR.
+  walkthrough table, and a review effort estimate. Called as part of the
+  comprehensive-review skill. Its output is used as the PR description when
+  creating a new PR.
 model: sonnet
 color: blue
 ---
@@ -62,27 +62,6 @@ row in the table. Example:
 Use judgment for grouping headers: "API Layer", "Data Layer", "Infrastructure", "Tests",
 "Config", "Docs", etc. — whatever fits the PR's structure.
 
-## Step 4: Generate `## Sequence Diagrams` (only when `DIAGRAMS=true`)
-
-**Only generate this section if the orchestrator passed `DIAGRAMS=true` in the task
-description. If `DIAGRAMS=false` or no `DIAGRAMS` flag was provided, omit the
-`## Sequence Diagrams` heading and its content entirely.**
-
-When generating diagrams: for each file modifying **control flow** (function call chains,
-API interactions, error paths, event handling), generate a Mermaid `sequenceDiagram` block
-showing the flow **after** the change.
-
-Rules:
-- Use `sequenceDiagram` type only.
-- **Maximum 10 participants and 15 interactions per diagram.**
-- Show the primary happy path, not every error branch.
-- Use descriptive labels on arrows (not "calls" or "returns").
-- Skip files that are purely data structures, configuration, documentation, test fixtures,
-  or minor cosmetic edits.
-
-If no files have meaningful control flow changes, write:
-> No significant control flow changes in this PR.
-
 ## Empty State
 
 If no diff or changed files are provided, output EXACTLY the word `NONE` and nothing else.
@@ -104,11 +83,6 @@ Produce exactly these sections in order, with no preamble:
 | File | Change | Summary |
 |------|--------|---------|
 <rows — grouped with bold headers when >10 files>
-
-## Sequence Diagrams
-
-<!-- Only present when DIAGRAMS=true; omit this section otherwise -->
-<diagrams or "No significant control flow changes in this PR.">
 
 ## Related Issues & PRs
 

--- a/skills/comprehensive-review/HELP.md
+++ b/skills/comprehensive-review/HELP.md
@@ -22,8 +22,6 @@ Flags
   --quick            Fast mode: pr-summarizer + code-reviewer + triggered error/test agents.
                      Skips security, architecture, blind-hunter, edge-case-hunter, comment,
                      and type analysis. Roughly 60–80% cheaper depending on diff composition.
-  --diagrams         Include Mermaid sequence diagrams in the summary (default: omitted;
-                     always omitted in --quick)
   --security-only    Run security-reviewer + CVE check (on changed dep manifests) only
   --summary-only     Run pr-summarizer only
 
@@ -68,7 +66,7 @@ Agents — full run
   Conditional:       silent-failure-hunter, pr-test-analyzer, comment-analyzer, type-design-analyzer
 
 Agents — --quick mode
-  Always:            pr-summarizer (no diagrams), code-reviewer
+  Always:            pr-summarizer, code-reviewer
   Conditional:       silent-failure-hunter, pr-test-analyzer (if patterns match)
   Skipped:           all full-run-only + comment-analyzer, type-design-analyzer, issue-linker
 

--- a/skills/comprehensive-review/SKILL.md
+++ b/skills/comprehensive-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: comprehensive-review
 description: "Run a comprehensive PR/MR review using specialized agents. Supports GitHub, GitLab, and Bitbucket. Use --post-summary/--post-findings to post results, --create-pr to create a PR, --pr <N> to review an existing PR."
-argument-hint: "[--quick] [--pr <N>] [--post-summary] [--post-findings] [--create-pr] [--depth deep] [--diagrams]"
+argument-hint: "[--quick] [--pr <N>] [--post-summary] [--post-findings] [--create-pr] [--depth deep]"
 allowed-tools: ["Bash", "Read", "Write", "Grep", "Glob", "Agent", "mcp__plugin_claude-mem_mcp-search__search", "mcp__plugin_claude-mem_mcp-search__get_observations"]
 ---
 
@@ -85,7 +85,7 @@ Note: GitHub inline review posting uses `gh api` (see OP: Post inline review in 
    - Extract `--base <branch>` if present, otherwise use the detected upstream base, falling back to `main`
    - Extract `--pr <number>` if present — set PR_NUMBER and enable external review mode
    - Extract `--provider <name>` if present — passed to Provider Detection (valid: `github`, `gitlab`, `bitbucket`)
-   - Note mode flags: `--quick`, `--diagrams`, `--security-only`, `--summary-only`, `--create-pr`,
+   - Note mode flags: `--quick`, `--security-only`, `--summary-only`, `--create-pr`,
      `--no-post`/`--local`, `--post-summary`, `--post-findings`, `--no-findings`, `--no-enrich-context`, `--no-mem`, `--no-suppress`
    - Extract `--output-file <path>` if present — set OUTPUT_FILE to the given path for Phase 5 file write
    - Extract `--depth <normal|deep>` if present; default DEPTH=`normal`. If value is not one of `{normal, deep}`, report "Error: Invalid --depth value '<value>'. Valid values are: normal, deep." and stop.
@@ -615,8 +615,8 @@ Produce slices via `mktemp /tmp/cr-slice-<agent>-XXXXXXXX.txt` and `git diff <ba
 
 | Flag | Agents that run |
 |------|-----------------|
-| (none) | All always-run + all triggered conditional agents (no diagrams unless `--diagrams` passed) + CVE check if manifest files changed + static analyzers if binaries available |
-| `--quick` | pr-summarizer (no diagrams) + code-reviewer + triggered silent-failure-hunter and pr-test-analyzer + CVE check if manifest files changed |
+| (none) | All always-run + all triggered conditional agents + CVE check if manifest files changed + static analyzers if binaries available |
+| `--quick` | pr-summarizer + code-reviewer + triggered silent-failure-hunter and pr-test-analyzer + CVE check if manifest files changed |
 | `DOCS_ONLY` (auto, no code/infra in diff) | pr-summarizer + code-reviewer + triggered silent-failure-hunter/pr-test-analyzer + CVE check; Opus agents skipped. Overridden by `--depth deep`, `--quick`, `--security-only`, `--summary-only`. Phase 5 reports auto-cheap reason. |
 | `LOW_RISK_CONFIG` (auto, config-only with no security patterns) | pr-summarizer + code-reviewer + deterministic checks; specialist Opus agents skipped. Phase 5 reports auto-cheap reason. |
 | `--no-post` / `--local` (explicit flag) | Same as default but also skips issue-linker; all Phase 4 operations suppressed |
@@ -665,7 +665,6 @@ Produce slices via `mktemp /tmp/cr-slice-<agent>-XXXXXXXX.txt` and `git diff <ba
 
 | Directive | Value | Consumed by | Default when absent |
 |-----------|-------|-------------|---------------------|
-| `DIAGRAMS` | `true` / `false` | pr-summarizer | `false` (omit diagrams) |
 | `EXTENDED_THINKING` | `true` | architecture-reviewer, security-reviewer | not set (standard reasoning) |
 | `RELATED_FILES` | newline-separated file paths | architecture-reviewer, security-reviewer | unset (no pointer list) |
 | `LANGUAGE_PROFILES` | concatenated markdown context blocks | architecture-reviewer, security-reviewer, adversarial-general, edge-case-hunter, silent-failure-hunter, code-reviewer, pr-test-analyzer | unset (agents use built-in language guidance) |
@@ -682,7 +681,6 @@ Rules: include directives as `KEY=value` on their own line at the start of the t
 
 - **pr-summarizer** (subagent_type: `comprehensive-review:pr-summarizer`, model: sonnet) — pass manifest, commit log, project context. Small diffs: also full diff inline.
   If GOVERNANCE_BLOCK is non-empty, prepend it under `GOVERNANCE:` (always — applies even at TIER=tiny).
-  If `--diagrams` was passed (and not `--quick`): include `DIAGRAMS=true` in the task description. Otherwise: include `DIAGRAMS=false`.
   If PR_NARRATIVE is non-empty, include it under `PR_NARRATIVE:`.
   **TIER=tiny:** use haiku instead of sonnet; pass only diff + PR title (drop manifest, commit log, project context, PR_NARRATIVE). GOVERNANCE_BLOCK is still included.
 - **code-reviewer** (subagent_type: `pr-review-toolkit:code-reviewer`, model: sonnet) — always pass the full diff.
@@ -1174,7 +1172,6 @@ Build two separate output blocks:
 #### Block A — Informational (conditionally posted to hosting provider)
 
 Assemble the pr-summarizer and issue-linker outputs into this format.
-**Omit the `## Sequence Diagrams` section unless `--diagrams` was passed** (pr-summarizer was told not to generate it).
 If issue-linker returned NONE or was skipped, omit the `## Related Issues & PRs` section entirely.
 
 **Degraded-mode banners:** prepend banners to Block A (before the `## Summary` heading) for any of the following degradation flags. If multiple flags are set, render multiple banners stacked.
@@ -1202,10 +1199,6 @@ If `REDACTION_DEGRADED=true` (set in Phase 2 step 2g when `perl` was unavailable
 | File | Change | Summary |
 |------|--------|---------|
 <rows from pr-summarizer>
-
-## Sequence Diagrams
-
-<from pr-summarizer — include only if --diagrams was passed and not --quick>
 
 ## Related Issues & PRs
 


### PR DESCRIPTION
## Summary

- Removes the `--diagrams` flag and Mermaid sequence diagram output from Block A entirely
- The feature was opt-in (default-off) and never worked reliably enough to keep
- A stale `--diagrams` in old scripts is silently ignored — it falls through as an unrecognized flag

## Changes

Touches 5 files, net -38 lines:

| File | What changed |
|------|-------------|
| `SKILL.md` | Removed `[--diagrams]` from argument-hint, flag from parse list, two mode-table parentheticals, `DIAGRAMS` directive-registry row, pr-summarizer spawn conditional, and the `## Sequence Diagrams` slot in the Block A template |
| `agents/pr-summarizer.md` | Removed Mermaid clause from frontmatter description, entire Step 4 (20 lines of DIAGRAMS gate + generation rules), and the `## Sequence Diagrams` block from the output template |
| `README.md` | Removed comparison table row, `--diagrams` flags table row, agent table entry, `--quick` section parenthetical, Block A description clause, and sample output block line |
| `CLAUDE.md` | Removed Block A architecture description reference and doc-sync maintenance note reference |
| `HELP.md` | Removed `--diagrams` flag entry and `--quick` agents roster parenthetical |

## Test plan

- [x] `grep -ri 'mermaid\|--diagrams\|DIAGRAMS\|sequence diagram'` across all `.md` and `.sh` files — zero hits
- [x] `bats tests/*.bats` — 150/150 pass