### PR TITLE
fix: correct suppressions.json path reference in shell.md language profile

### DIFF
--- a/skills/comprehensive-review/language-profiles/shell.md
+++ b/skills/comprehensive-review/language-profiles/shell.md
@@ -43,7 +43,7 @@ When reviewing shell scripts, pay particular attention to:
 ### Project-Accepted Patterns
 
 Finding suppressions for won't-fix items and false positives are managed
-declaratively in `suppressions.json` (at the repo root). Do not re-flag
+declaratively in `suppressions.json`. Do not re-flag
 any pattern listed there. Current suppressions include:
 
 - `SC1072` on `run-shellcheck.sh` — shellcheck heredoc false positive; `bash -n` passes


### PR DESCRIPTION
## Summary

- Corrects the `suppressions.json` path reference in `skills/comprehensive-review/language-profiles/shell.md`
- The file lives at `skills/comprehensive-review/suppressions.json`, not at the repo root as previously stated

## Test plan

- [ ] Confirm the path reference matches the actual file location
- [ ] No other files changed

Closes #411