### PR TITLE
docs(security): mandate jq payload construction in PROVIDERS.md (MEDIUM, #105)

### DIFF
--- a/skills/comprehensive-review/PROVIDERS.md
+++ b/skills/comprehensive-review/PROVIDERS.md
@@ -83,8 +83,9 @@ SKILL.md for `jq -n --arg`). The OP templates below all follow it.
   # findings.jsonl contains one JSON object per inline finding:
   #   {"path": "<file>", "line": <line>, "body": "<comment>"}
   # Built upstream via jq from the structured findings (never via string interpolation).
-  touch findings.jsonl  # mandatory guard: no inline findings is a valid state; jq -s '.' on an empty file yields []
-  COMMENTS=$(jq -s '.' findings.jsonl) || { echo 'ERROR: failed to aggregate findings.jsonl'; exit 1; }  # array
+  touch findings.jsonl  # mandatory: do not skip -- ensures jq -s '.' always has a file to read
+  COMMENTS=$(jq -s '.' findings.jsonl) || { echo 'ERROR: jq failed aggregating findings.jsonl'; exit 1; }
+  [[ "$COMMENTS" == '[]' || "$COMMENTS" == '['* ]] || { echo 'ERROR: unexpected COMMENTS value'; exit 1; }
   EVENT="REQUEST_CHANGES"               # or COMMENT, computed from severities
   REVIEW_BODY=$(jq -n \
     --arg event   "$EVENT" \

--- a/skills/comprehensive-review/PROVIDERS.md
+++ b/skills/comprehensive-review/PROVIDERS.md
@@ -83,7 +83,8 @@ SKILL.md for `jq -n --arg`). The OP templates below all follow it.
   # findings.jsonl contains one JSON object per inline finding:
   #   {"path": "<file>", "line": <line>, "body": "<comment>"}
   # Built upstream via jq from the structured findings (never via string interpolation).
-  COMMENTS=$(jq -s '.' findings.jsonl)  # array
+  touch findings.jsonl  # ensure file exists even when no inline findings were emitted
+  COMMENTS=$(jq -s '.' findings.jsonl) || { echo 'ERROR: failed to aggregate findings.jsonl'; exit 1; }  # array
   EVENT="REQUEST_CHANGES"               # or COMMENT, computed from severities
   REVIEW_BODY=$(jq -n \
     --arg event   "$EVENT" \

--- a/skills/comprehensive-review/PROVIDERS.md
+++ b/skills/comprehensive-review/PROVIDERS.md
@@ -26,23 +26,86 @@ If the provider response does not include a body/description field or the value 
 - **gitlab:** `glab mr list --source-branch "$(git branch --show-current)" --output json` (returns `[]` when no MR exists)
 - **bitbucket:** `curl -sf --user "${BITBUCKET_EMAIL}:${BITBUCKET_TOKEN}" "https://api.bitbucket.org/2.0/repositories/${REPO_SLUG}/pullrequests?q=source.branch.name=\"$(git branch --show-current)\"&state=OPEN"`. If `curl` exits non-zero or the response contains `"type":"error"`, treat as API failure (not "no PR found"). Otherwise check `.size > 0`; if so, first result is the PR.
 
+## Safe payload construction (mandatory)
+
+Any time the orchestrator builds a JSON request body from values that originate
+in attacker-influenceable content (PR title, PR/MR description body, finding
+text, file paths, branch names, etc.), construct the JSON with `jq -n --arg`
+and pass it via `--data-binary "$BODY"` (or the equivalent `--input` for
+`gh api`). Never build a JSON request body by interpolating those values into
+a string literal that is passed to `curl -d` or `gh api -f` — an unescaped
+double-quote, backslash, or newline in any input field breaks out of the
+template and clobbers sibling fields.
+
+This is the same pattern SKILL.md mandates for the claude-mem save (search
+SKILL.md for `jq -n --arg`). The OP templates below all follow it.
+
 ## OP: Create PR/MR
 
-- **github:** `gh pr create --title "<title>" --base "<base>" --body "<body>"`
-- **gitlab:** `glab mr create --title "<title>" --target-branch "<base>" --description "<body>" --no-editor`
-- **bitbucket:** `curl -sf -X POST --user "${BITBUCKET_EMAIL}:${BITBUCKET_TOKEN}" -H "Content-Type: application/json" "https://api.bitbucket.org/2.0/repositories/${REPO_SLUG}/pullrequests" -d '{"title":"<title>","source":{"branch":{"name":"<head>"}},"destination":{"branch":{"name":"<base>"}},"description":"<body>"}'`
+- **github:** `gh pr create --title "<title>" --base "<base>" --body "<body>"` (the `gh` CLI handles arg quoting; safe).
+- **gitlab:** `glab mr create --title "<title>" --target-branch "<base>" --description "<body>" --no-editor` (the `glab` CLI handles arg quoting; safe).
+- **bitbucket:** Build the body with `jq -n --arg` and post it via `--data-binary`:
+  ```bash
+  BODY=$(jq -n \
+    --arg title  "<title>" \
+    --arg head   "<head>" \
+    --arg base   "<base>" \
+    --arg desc   "<body>" \
+    '{title: $title,
+      source:      {branch: {name: $head}},
+      destination: {branch: {name: $base}},
+      description: $desc}')
+  curl -sf -X POST \
+    --user "${BITBUCKET_EMAIL}:${BITBUCKET_TOKEN}" \
+    -H "Content-Type: application/json" \
+    --data-binary "$BODY" \
+    "https://api.bitbucket.org/2.0/repositories/${REPO_SLUG}/pullrequests"
+  ```
 
 ## OP: Post comment on PR/MR
 
-- **github:** `gh pr comment <N> --body "<body>"`
-- **gitlab:** `glab mr comment <N> --message "<body>"`
-- **bitbucket:** `curl -sf -X POST --user "${BITBUCKET_EMAIL}:${BITBUCKET_TOKEN}" -H "Content-Type: application/json" "https://api.bitbucket.org/2.0/repositories/${REPO_SLUG}/pullrequests/<N>/comments" -d '{"content":{"raw":"<body>"}}'`
+- **github:** `gh pr comment <N> --body "<body>"` (the `gh` CLI handles arg quoting; safe).
+- **gitlab:** `glab mr comment <N> --message "<body>"` (the `glab` CLI handles arg quoting; safe).
+- **bitbucket:** Build the body with `jq -n --arg` and post it via `--data-binary`:
+  ```bash
+  BODY=$(jq -n --arg body "<body>" '{content: {raw: $body}}')
+  curl -sf -X POST \
+    --user "${BITBUCKET_EMAIL}:${BITBUCKET_TOKEN}" \
+    -H "Content-Type: application/json" \
+    --data-binary "$BODY" \
+    "https://api.bitbucket.org/2.0/repositories/${REPO_SLUG}/pullrequests/<N>/comments"
+  ```
 
 ## OP: Post inline review (Phase 4b only)
 
-- **github:** `gh api repos/{owner}/{repo}/pulls/{pull_number}/reviews` with JSON body `{"event":"REQUEST_CHANGES"|"COMMENT","body":"<review body>","comments":[{"path":"<file>","line":<line>,"body":"<comment>"},...]}`. Use `REQUEST_CHANGES` when any finding is Medium or higher; use `COMMENT` when all findings are Low. Owner and repo are extracted from the git remote URL.
-- **gitlab:** Create a review via Draft Notes API or post individual discussion threads:
-  For each inline comment (shell-escape all interpolated values — body, file path, line — to prevent injection via crafted filenames or review content): `glab api -X POST "projects/${PROJECT_ID}/merge_requests/<N>/discussions" -f "body=<body>" -f "position[base_sha]=<base_sha>" -f "position[head_sha]=<head_sha>" -f "position[start_sha]=<start_sha>" -f "position[position_type]=text" -f "position[new_path]=<file>" -f "position[new_line]=<line>"`.
-  For the review body: `glab mr comment <N> --message "<review body>"`.
-  GitLab does not have a single-call "submit review with inline comments" API like GitHub. Inline comments are posted as discussion threads. There is no REQUEST_CHANGES event — use an "unapprove" or simply post as comments.
+- **github:** Build the comments array with `jq` from a finding-source file (one row per finding: file, line, comment), assemble the full review body with `jq -n --arg`/`--slurpfile`, and post via `gh api --input`. Choose `event` based on finding severity (`REQUEST_CHANGES` if any finding is Medium or higher; otherwise `COMMENT`). Owner and repo are extracted from the git remote URL.
+  ```bash
+  # findings.jsonl contains one JSON object per inline finding:
+  #   {"path": "<file>", "line": <line>, "body": "<comment>"}
+  # Built upstream via jq from the structured findings (never via string interpolation).
+  COMMENTS=$(jq -s '.' findings.jsonl)  # array
+  EVENT="REQUEST_CHANGES"               # or COMMENT, computed from severities
+  REVIEW_BODY=$(jq -n \
+    --arg event   "$EVENT" \
+    --arg body    "<review body>" \
+    --argjson cmts "$COMMENTS" \
+    '{event: $event, body: $body, comments: $cmts}')
+  echo "$REVIEW_BODY" | gh api --input - \
+    "repos/{owner}/{repo}/pulls/{pull_number}/reviews"
+  ```
+- **gitlab:** Post each inline finding as an individual discussion thread using `glab api -f key=value` (the `-f` form URL-encodes each value; safe). Do not concatenate values into a single quoted string.
+  ```bash
+  # For each inline comment:
+  glab api -X POST "projects/${PROJECT_ID}/merge_requests/<N>/discussions" \
+    -f "body=<body>" \
+    -f "position[base_sha]=<base_sha>" \
+    -f "position[head_sha]=<head_sha>" \
+    -f "position[start_sha]=<start_sha>" \
+    -f "position[position_type]=text" \
+    -f "position[new_path]=<file>" \
+    -f "position[new_line]=<line>"
+  # Review body posted as an MR comment (glab handles arg quoting):
+  glab mr comment <N> --message "<review body>"
+  ```
+  GitLab has no single-call "submit review with inline comments" API like GitHub. There is no REQUEST_CHANGES event — use "unapprove" or post as comments.
 - **bitbucket:** NOT SUPPORTED for inline diff comments. Post Block B as a single PR comment instead (using OP: Post comment). Note in terminal output: "Note: Inline review comments are not supported on Bitbucket. Findings posted as a PR comment."

--- a/skills/comprehensive-review/PROVIDERS.md
+++ b/skills/comprehensive-review/PROVIDERS.md
@@ -83,7 +83,7 @@ SKILL.md for `jq -n --arg`). The OP templates below all follow it.
   # findings.jsonl contains one JSON object per inline finding:
   #   {"path": "<file>", "line": <line>, "body": "<comment>"}
   # Built upstream via jq from the structured findings (never via string interpolation).
-  touch findings.jsonl  # ensure file exists even when no inline findings were emitted
+  touch findings.jsonl  # mandatory guard: no inline findings is a valid state; jq -s '.' on an empty file yields []
   COMMENTS=$(jq -s '.' findings.jsonl) || { echo 'ERROR: failed to aggregate findings.jsonl'; exit 1; }  # array
   EVENT="REQUEST_CHANGES"               # or COMMENT, computed from severities
   REVIEW_BODY=$(jq -n \

--- a/skills/comprehensive-review/SKILL.md
+++ b/skills/comprehensive-review/SKILL.md
@@ -1379,7 +1379,12 @@ Only treat **non-zero exit code** as failure: set `POSTED_COMMENT_REF=""` and `P
    <BODY findings, or "None — all findings are attached inline.">
    ```
 
-6. **Comments array:** each entry `{ "path", "line", "body": "**[Severity]** **[agent]** description.\n\n**Remediation:** ..." }`. **Build the array with `jq -n --arg`/`--arg` per field, never by string-concatenating the values into a JSON literal** — `path` and `body` may contain attacker-influenced content (file paths from the diff, finding text derived from PR/commit content) and a stray double-quote, backslash, or newline would break the literal and inject sibling fields. See PROVIDERS.md → "OP: Post inline review" → **github** for the full safe-construction pattern (a per-finding `findings.jsonl` built via `jq -n --arg`, then aggregated via `jq -s '.'`).
+6. **Comments array:** each entry `{ "path", "line", "body": "**[Severity]** **[agent]** description.\n\n**Remediation:** ..." }`. **Build the array with `jq -n --arg`/`--arg` per field, never by string-concatenating the values into a JSON literal** — `path` and `body` may contain attacker-influenced content (file paths from the diff, finding text derived from PR/commit content) and a stray double-quote, backslash, or newline would break the literal and inject sibling fields. For each finding, write one row to `findings.jsonl` using:
+   ```bash
+   jq -n --arg path "$FILE" --argjson line "$LINE" --arg body "$BODY" \
+     '{path: $path, line: $line, body: $body}' >> findings.jsonl
+   ```
+   Then aggregate via `jq -s '.'`. See PROVIDERS.md → "OP: Post inline review" → **github** for the full pattern including the `touch findings.jsonl` guard and the error-checked aggregation step.
 
 7. **Confirm with user before submitting:** Display the review event type (`COMMENT` or `REQUEST_CHANGES`), the full review body, and a summary of inline comments (count + each as `<file>:<line> [Severity] <one-line description>`). Ask: "Post this review to ${PR_TERM} #<N>? (yes/no)". Do not proceed unless the user confirms. If the user declines or requests changes, apply any edits they specify and re-display before asking again.
 

--- a/skills/comprehensive-review/SKILL.md
+++ b/skills/comprehensive-review/SKILL.md
@@ -1384,7 +1384,7 @@ Only treat **non-zero exit code** as failure: set `POSTED_COMMENT_REF=""` and `P
    # Validate LINE is a positive integer before passing to --argjson; a non-numeric value
    # (e.g., "null", "N/A", or empty string from LLM output) causes jq to exit non-zero and
    # silently drop the finding.  Fall back to 1 rather than skipping the finding entirely.
-   [[ "$LINE" =~ ^[0-9]+$ ]] || LINE=1
+   [[ "$LINE" =~ ^[1-9][0-9]*$ ]] || LINE=1
    jq -n --arg path "$FILE" --argjson line "$LINE" --arg body "$BODY" \
      '{path: $path, line: $line, body: $body}' >> findings.jsonl
    ```

--- a/skills/comprehensive-review/SKILL.md
+++ b/skills/comprehensive-review/SKILL.md
@@ -1381,6 +1381,10 @@ Only treat **non-zero exit code** as failure: set `POSTED_COMMENT_REF=""` and `P
 
 6. **Comments array:** each entry `{ "path", "line", "body": "**[Severity]** **[agent]** description.\n\n**Remediation:** ..." }`. **Build the array with `jq -n --arg`/`--arg` per field, never by string-concatenating the values into a JSON literal** — `path` and `body` may contain attacker-influenced content (file paths from the diff, finding text derived from PR/commit content) and a stray double-quote, backslash, or newline would break the literal and inject sibling fields. For each finding, write one row to `findings.jsonl` using:
    ```bash
+   # Validate LINE is a positive integer before passing to --argjson; a non-numeric value
+   # (e.g., "null", "N/A", or empty string from LLM output) causes jq to exit non-zero and
+   # silently drop the finding.  Fall back to 1 rather than skipping the finding entirely.
+   [[ "$LINE" =~ ^[0-9]+$ ]] || LINE=1
    jq -n --arg path "$FILE" --argjson line "$LINE" --arg body "$BODY" \
      '{path: $path, line: $line, body: $body}' >> findings.jsonl
    ```

--- a/skills/comprehensive-review/SKILL.md
+++ b/skills/comprehensive-review/SKILL.md
@@ -1379,7 +1379,7 @@ Only treat **non-zero exit code** as failure: set `POSTED_COMMENT_REF=""` and `P
    <BODY findings, or "None — all findings are attached inline.">
    ```
 
-6. **Comments array:** each entry `{ "path", "line", "body": "**[Severity]** **[agent]** description.\n\n**Remediation:** ..." }`
+6. **Comments array:** each entry `{ "path", "line", "body": "**[Severity]** **[agent]** description.\n\n**Remediation:** ..." }`. **Build the array with `jq -n --arg`/`--arg` per field, never by string-concatenating the values into a JSON literal** — `path` and `body` may contain attacker-influenced content (file paths from the diff, finding text derived from PR/commit content) and a stray double-quote, backslash, or newline would break the literal and inject sibling fields. See PROVIDERS.md → "OP: Post inline review" → **github** for the full safe-construction pattern (a per-finding `findings.jsonl` built via `jq -n --arg`, then aggregated via `jq -s '.'`).
 
 7. **Confirm with user before submitting:** Display the review event type (`COMMENT` or `REQUEST_CHANGES`), the full review body, and a summary of inline comments (count + each as `<file>:<line> [Severity] <one-line description>`). Ask: "Post this review to ${PR_TERM} #<N>? (yes/no)". Do not proceed unless the user confirms. If the user declines or requests changes, apply any edits they specify and re-display before asking again.
 


### PR DESCRIPTION
## Summary

Provider POST bodies (Bitbucket create-PR/comment and GitHub inline review) were specified to build the JSON request body by interpolating `<title>` / `<body>` / `<head>` / `<file>` values directly into a literal JSON string passed to `curl -d` or `gh api`. Those values derive from attacker-influenceable content (PR title, PR description body, finding text, file paths from the diff). An unescaped double-quote, backslash, or newline in any of those fields breaks out of the literal and clobbers sibling fields.

The skill already mandates `jq -n --arg` for the claude-mem save (`SKILL.md:1425`). This PR applies the same pattern uniformly across the provider OPs.

Fixes #105.

## What changed

`skills/comprehensive-review/PROVIDERS.md`:

- New **Safe payload construction (mandatory)** preamble.
- **OP: Create PR/MR (bitbucket)** rewritten to build the body via `jq -n --arg` and post via `--data-binary`.
- **OP: Post comment on PR/MR (bitbucket)** rewritten the same way.
- **OP: Post inline review (github)** rewritten to build the comments array from a per-finding `findings.jsonl` (each row constructed with `jq -n --arg`) and aggregated with `jq -s '.'` before being passed to `gh api --input`.
- The GitLab "shell-escape all interpolated values" prose instruction is replaced with a concrete `glab api -f key=value` example (the `-f` form URL-encodes each value; no manual escaping required).
- Existing `gh`/`glab` CLI invocations are kept as-is and noted as safe (those CLIs handle arg quoting).

`skills/comprehensive-review/SKILL.md`:

- Phase 4b step 6 (the comments-array construction step) gains a one-line cross-reference to the safe-construction pattern in PROVIDERS.md. Without this, the existing `--input <comments_json_file>` line is safe at the API call but moot if the orchestrator built that file freehand.

## Why a doc-only PR fixes this

The skill is consumed by an LLM at runtime. Concrete code examples in PROVIDERS.md are the operative spec; the LLM follows them when constructing the actual command. Replacing string-interpolation templates with `jq -n --arg` templates structurally prevents the injection class — there is no quote/backslash an attacker can put in `body` that breaks out of `--arg "$BODY"`.

## Rejected alternative

Adding a runtime validator that scans the proposed POST body for invalid JSON before sending. Rejected because (a) the body has already left the orchestrator at that point — too late to influence what gets posted; (b) the doc-fix structurally prevents the issue at construction time; (c) a validator catches malformed JSON, not deliberate injection that produces *valid* JSON with attacker-controlled fields.

## Test plan

- [x] PROVIDERS.md renders correctly on github.com (markdown, code fences)
- [ ] In a manual review run with `--create-pr` against a PR whose body contains `"`, `\`, and newlines, the resulting Bitbucket payload is valid JSON and the body is preserved verbatim
- [ ] In a manual review run with `--post-inline-review` against a PR with a finding that has a backtick/quote-heavy file path, the GitHub `gh api --input` call succeeds and the inline comment renders correctly
- [x] No regression on the GitHub/GitLab `gh pr create` / `glab mr create` paths (those didn't change)