### PR TITLE
ci(security): SHA-pin ruby/setup-ruby in pages.yml (#107)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,7 +25,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        # Third-party (non-actions/*) action; pinned to a commit SHA per the
+        # policy in agents/security-reviewer.md L102. Renovate will manage
+        # SHA bumps via the existing tag1consulting/renovate-config.
+        uses: ruby/setup-ruby@12fd324f1d0b43274fdc8130f6980590a667c455  # v1.312.0
         with:
           ruby-version: '4.0.5'
           bundler-cache: true


### PR DESCRIPTION
## Summary

Pin the third-party `ruby/setup-ruby` action in `pages.yml` to an immutable commit SHA, with a version comment. Renovate will manage SHA bumps via the existing `tag1consulting/renovate-config`.

Fixes #107.

## What this PR pins

| Action | Old | New | Release |
|---|---|---|---|
| ruby/setup-ruby | `@v1` | `@12fd324f1d0b43274fdc8130f6980590a667c455` | v1.312.0 |

## What this PR does not pin (and why)

Per the documented policy in [`agents/security-reviewer.md` L102](https://github.com/tag1consulting/claude-comprehensive-review/blob/main/agents/security-reviewer.md#L102):

> Do NOT flag `actions/*@vN` floating major-version tags in GitHub Actions workflows — this is a deliberate policy to receive automatic security patches. Only flag third-party actions using `@latest` or no version pin at all.

So these stay on their floating major refs:

- `actions/checkout@v6` (pages.yml, ai-pr-review.yml)
- `actions/configure-pages@v6`
- `actions/upload-pages-artifact@v5`
- `actions/deploy-pages@v5`

And `tag1consulting/ai-pr-review/container-action@main` (in `ai-pr-review.yml`) stays on `@main` per the dogfooding/canary policy. The "never execute checked-out code" invariant ([ai-pr-review SECURITY.md](https://github.com/tag1consulting/ai-pr-review/blob/main/SECURITY.md), tag1consulting/ai-pr-review#491) is the load-bearing mitigation there.

## Threat model on Pages workflow

`pages.yml` triggers on `push` to `main`, so the `pull_request_target`/fork-PR risk does not apply. It does grant `pages: write` and `id-token: write`. A tag-move attack on `ruby/setup-ruby@v1` would run upstream-attacker code with those permissions; SHA pinning structurally prevents that.

## Test plan

- [ ] Workflow YAML still parses
- [ ] Next push to main builds and deploys docs successfully (this is the only consumer of pages.yml)
- [ ] Renovate begins offering SHA bumps for `ruby/setup-ruby` within ~1 week