### PR TITLE
feat: wire fail-on-findings + review-gate for automerge-safe branch protection

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -68,6 +68,24 @@ jobs:
           # vars.AI_REVIEW_FEEDBACK_LOOP loads recent /ai-pr-review feedback
           # entries from the ai-pr-review-bot branch (default false).
           feedback-loop: ${{ vars.AI_REVIEW_FEEDBACK_LOOP || 'false' }}
+          # vars.AI_REVIEW_FAIL_ON_FINDINGS exits with code 2 when the review
+          # outcome is REQUEST_CHANGES or COMMENT, blocking CI gates until the
+          # bot approves.  Consumed by the review-gate job below.
+          fail-on-findings: ${{ vars.AI_REVIEW_FAIL_ON_FINDINGS || 'false' }}
+
+  review-gate:
+    name: review-gate
+    needs: review
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Gate on review outcome
+        run: |
+          if [ "${{ needs.review.result }}" = "failure" ]; then
+            echo "AI review failed — blocking merge." >&2
+            exit 1
+          fi
+          echo "AI review passed or was skipped."
 
   cleanup-rescan-label:
     needs: review

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>tag1consulting/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- Sets repo variable `AI_REVIEW_FAIL_ON_FINDINGS=true` (already applied) and wires it to the container-action's `fail-on-findings` input so the workflow exits with code 2 when the AI review result is `REQUEST_CHANGES` or `COMMENT`.
- Adds a `review-gate` job (`if: always()`) that gates on the `review` job outcome: passes on `success` or `skipped`, fails only on `failure`. This is the check to register as the required status on `main` — it allows `renovate[bot]` and `dependabot[bot]` PRs (which skip `review`) to still pass the gate and automerge.
- Enables renovate `automerge: true` scoped to `minor` and `patch` updates in `renovate.json`.

## Why review-gate instead of review

The `review` job is skipped for `renovate[bot]` and `dependabot[bot]` (lines 20-21 of the workflow). A skipped check never satisfies a required status check on GitHub, so requiring `review` directly would permanently block all bot PRs. `review-gate` (`if: always()`) runs unconditionally and reports success when `review` is skipped.

## Security note

The only expression interpolated into the `review-gate` `run:` block is `${{ needs.review.result }}`, which is a GitHub Actions internal enum (`success`/`failure`/`cancelled`/`skipped`) — not user-controlled input. No injection risk.

## After merge

Enable branch protection on `main` requiring the `review-gate` status check to pass. (This is a Checkpoint Trigger and will be confirmed separately before executing.)

## Test plan

- [ ] Open a test PR from a non-bot actor — verify `review` runs, `review-gate` reports based on its outcome
- [ ] Verify a renovate/dependabot PR shows `review` as skipped and `review-gate` as passed
- [ ] Verify `AI_REVIEW_FAIL_ON_FINDINGS` variable is set to `true` in repo settings