### PR TITLE
feat: run AI review on all PRs including renovate and dependabot

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -17,8 +17,6 @@ jobs:
   review:
     if: >-
       github.event.pull_request.draft == false &&
-      github.actor != 'dependabot[bot]' &&
-      github.actor != 'renovate[bot]' &&
       !contains(github.event.pull_request.labels.*.name, 'skip-ai-review') &&
       (github.event.action != 'labeled' ||
        github.event.label.name == 'ai-review-full' ||
@@ -69,23 +67,8 @@ jobs:
           # entries from the ai-pr-review-bot branch (default false).
           feedback-loop: ${{ vars.AI_REVIEW_FEEDBACK_LOOP || 'false' }}
           # vars.AI_REVIEW_FAIL_ON_FINDINGS exits with code 2 when the review
-          # outcome is REQUEST_CHANGES or COMMENT, blocking CI gates until the
-          # bot approves.  Consumed by the review-gate job below.
+          # outcome is REQUEST_CHANGES or COMMENT, blocking automerge.
           fail-on-findings: ${{ vars.AI_REVIEW_FAIL_ON_FINDINGS || 'false' }}
-
-  review-gate:
-    name: review-gate
-    needs: review
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Gate on review outcome
-        run: |
-          if [ "${{ needs.review.result }}" = "failure" ]; then
-            echo "AI review failed — blocking merge." >&2
-            exit 1
-          fi
-          echo "AI review passed or was skipped."
 
   cleanup-rescan-label:
     needs: review


### PR DESCRIPTION
## Summary

- Removes `github.actor != 'dependabot[bot]'` and `github.actor != 'renovate[bot]'` skip conditions from the `review` job's `if:` clause — every non-draft PR now gets an AI review
- Removes the `review-gate` wrapper job (it was only needed to pass branch protection when bots were skipped)

## Motivation

The automerge path (`renovate.json` `automerge: true` + `fail-on-findings: true`) works directly off the `review` job exit code. A separate gate is unnecessary now that the review always runs. The `skip-ai-review` label remains as a per-PR escape hatch for noisy bot batches.

## Branch protection follow-up

After this merges, branch protection on `main` needs to be updated to require the `review` check instead of `review-gate`. That API call will be made after merge.

## Test plan

- [ ] Open a non-draft PR — `review` job should run (previously did)
- [ ] Simulate a renovate/dependabot PR — `review` job should now run (previously skipped)
- [ ] Confirm `cleanup-rescan-label` still runs (`needs: review` with `if: always()`)
- [ ] Confirm no `review-gate` job appears in the Actions run