### PR TITLE
chore(renovate): add automergeType pr for minor/patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,8 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true
+      "automerge": true,
+      "automergeType": "pr"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds `automergeType: "pr"` to the minor/patch package rule so Renovate uses GitHub's native PR auto-merge instead of the branch-merge default.

The repo already has `allow_auto_merge: true` and branch protection requires the `review` status check (ai-pr-review). With this change, Renovate PRs will auto-merge as soon as ai-pr-review approves them.

## Test plan

- [ ] Verify next Renovate PR auto-merges after ai-pr-review approves it