### PR TITLE
security-reviewer: add SSRF, XXE, and LLM prompt-injection checks

### DIFF
--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -82,6 +82,8 @@ or the anti-hallucination rules on version/release claims.
 - Path traversal: user-controlled file paths without sanitization
 - Template injection: user input rendered in templates
 - GraphQL injection: dynamic query construction from user input
+- Server-Side Request Forgery (SSRF): user-controlled URLs passed to outbound HTTP clients; verify redirects, internal host ranges, and cloud metadata endpoints (169.254.x.x, fd00::/8) are blocked
+- LLM prompt injection: user-controlled content interpolated directly into prompts sent to language models; flag any direct interpolation of PR content, commit messages, or filenames into LLM calls without sanitization
 
 ### Data Handling and Privacy
 - PII or sensitive data written to logs
@@ -110,6 +112,12 @@ or the anti-hallucination rules on version/release claims.
 
   A renovate/dependabot bump to a higher version number is strong positive evidence the version exists. If uncertain whether a version exists, **omit the finding entirely** — do not emit at Low confidence or hedge with "may" or "should verify." Deterministic version verification is handled by the CVE scanner and the verify-gated suppression path.
 - Known CVEs in direct dependencies are detected deterministically by the `dependency-check` step (Phase 1b); do not re-flag those. Report dependency-related security concerns beyond CVE matches: maintainer changes, typosquat suspicion, overly broad permissions, or new license concerns.
+
+## XML External Entity (XXE)
+
+Flag use of Python's standard-library XML parsers on untrusted input without disabling external entities:
+- `xml.etree.ElementTree.parse/fromstring`, `xml.dom.minidom.parse/parseString`, `xml.sax.parse/parseString`
+- These are vulnerable to XXE by default; the fix is `defusedxml` or explicit `xml.sax.handler.feature_external_ges = False`
 
 ## Language-Specific Checks
 


### PR DESCRIPTION
## Summary

- Adds two checks to the `### Injection` subsection of `agents/security-reviewer.md`: Server-Side Request Forgery (SSRF) and LLM prompt injection.
- Adds a new `## XML External Entity (XXE)` section covering Python stdlib XML parsers on untrusted input.
- Content ported verbatim from `ai-pr-review`'s `prompts/security-reviewer.md` (SSRF/LLM-injection at source line 40-41, XXE section at source lines 83-87), closing the coverage gap identified by the 2026-07-06 parity audit.

All three checks map to the existing `injection` category in the json-findings schema — no schema, roster, or flags changes needed.

## Test plan

- [x] `grep -nE 'SSRF|XXE|External Entity|prompt injection' agents/security-reviewer.md` — confirms all three additions present
- [x] Structural check: XXE H2 sits between `## Universal Security Checks` and `## Language-Specific Checks`; `### Injection` subsection has its original 5 bullets plus 2 new ones
- [x] `category` enum (line 224) unchanged
- [x] `git diff --stat` shows only `agents/security-reviewer.md` changed
- [ ] Optional live smoke test: run `/comprehensive-review` against a diff with an unvalidated `requests.get(user_url)` and an `xml.etree.ElementTree.fromstring(untrusted)` call, confirm both surface as findings

Closes #123