### PR TITLE
Release v1.13.0: docs audit and phpcs fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.13.0] - Unreleased
+## [1.13.0] - 2026-07-16
 
 ### ⚠ Behavior change
 
@@ -19,9 +19,21 @@ and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - New Orchestrator Governance rule: "Draft mode never publishes" — explicitly forbids calling any submit/publish endpoint (GitHub review-events, GitLab `bulk_publish`) while staging.
 - New structural tests in `tests/orchestration_contracts.bats` assert the draft OP never contains a live invocation of a publish/submit endpoint, and that `--draft`/`--publish`/`--read-back` are documented consistently across `SKILL.md`, `README.md`, `CLAUDE.md`, and `HELP.md`.
 
+### Fixed
+
+- **GitHub read-back's PENDING-review filter no longer uses an unresolved placeholder or invalid syntax.** Two bugs were found and fixed during live E2E and multi-agent review of this feature before release: an early version compared `.user.login` against a literal, never-resolved `"<self>"` string; a later fix for that introduced an invalid `gh api --jq --arg` invocation (`gh api`'s `--jq` flag takes exactly one query string and does not support jq's own `--arg`). Both made GitHub `--read-back` non-functional as written. Fixed by resolving the invoking user's login via `gh api user --jq .login` and piping the pending-review query to a standalone `jq --arg` call.
+- **The GitHub pending-review pre-check no longer silently reports "0 pending reviews" when the login lookup fails.** A prior version fell back to an empty-string login on lookup failure and queried with it — an empty string can never match a real GitHub login, so the pre-check always returned a false "all clear" instead of genuinely skipping the check. It now skips the query entirely on lookup failure and warns explicitly.
+- **GitLab read-back's net-new-finding staging no longer risks a stale-SHA race.** The diff-version SHAs used to position a new draft note were previously captured once at Phase 4b entry, before the full analysis pipeline reruns and the user confirms staging — an arbitrarily long window during which a new commit on the MR could make those SHAs stale. The SHAs are now re-fetched immediately before the staging call, and a failed re-fetch is reported as a distinct error rather than being misreported through the generic inline-post-failure path.
+- **Four missing `--read-back` flag-conflict checks added**, closing gaps found across two independent review passes: `--read-back` combined with `--publish`/`--draft` previously produced a contradictory error-message loop (each error told the user to do the thing the other error forbade); `--read-back` combined with `--create-pr` on a branch with no existing PR/MR silently created a new PR and then ran the read-back against it, which by construction could have no prior draft.
+- Corrected an overstated claim that GitHub's REST docs guarantee PENDING reviews are visible only to their author — the docs confirm the not-yet-submitted state but do not document an explicit access-control guarantee for who can see it beforehand. The docs and code comments now describe "unpublished" as the verified property and "author-only visible" as a reasonable but unverified assumption.
+- Added a documented rollback path ("if draft mode misbehaves") for the (unlikely, but possible) case that a future GitHub or GitLab API change breaks the draft-staging invariant, plus a runtime notice appended to every successful draft-staging report reminding the user to confirm the review shows as Pending/draft in the web UI before sharing the PR link.
+- Added a runtime migration notice printed when `--post-findings` is used without `--publish` or an explicit `--draft`, so a script or CI job that relied on the pre-1.13.0 immediate-publish default gets a live signal that behavior changed, not just a silent change in outcome.
+- Fixed a pre-existing, unrelated bug in `run-phpcs.sh`: `$PHPCS_STANDARD` was only initialized on the live-`phpcs` code path, leaving it unbound (and the resulting `jq` call silently discarding findings) whenever the mock/offline path was used — including every run of the bats test suite. Now initialized unconditionally.
+
 ### Known limitations
 
 - Bitbucket draft-review support is out of scope this release: the Cloud REST v2 comment schema has a `pending` field, but creating a pending comment via the public API is not confirmed in Atlassian's official documentation (the "Batched comments" feature is documented as UI-driven). Revisit with a live API spike.
+- GitLab's draft-note staging and `--read-back` net-new-finding staging paths were not exercised against a live GitLab instance for this release — only GitHub was live-E2E-tested. Both are covered by structural bats tests asserting API-call shape, not by a live run. Treat the GitLab path as less battle-tested than GitHub's until a live GitLab E2E is performed.
 
 ## [1.12.2] - 2026-06-24
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository purpose
 
-This repo distributes a Claude Code skill (`/comprehensive-review`) and seven custom agents as a Claude Code plugin. The skill supports GitHub (including Enterprise), GitLab, and Bitbucket repositories. Deliverables are markdown files distributed via the `tag1consulting` plugin marketplace. The deterministic bash helpers have a bats test suite (`tests/*.bats`, 150 tests); run with `bats tests/*.bats` (requires `bats` and `jq`).
+This repo distributes a Claude Code skill (`/comprehensive-review`) and seven custom agents as a Claude Code plugin. The skill supports GitHub (including Enterprise), GitLab, and Bitbucket repositories. Deliverables are markdown files distributed via the `tag1consulting` plugin marketplace. The deterministic bash helpers have a bats test suite (`tests/*.bats`, 184 tests); run with `bats tests/*.bats` (requires `bats` and `jq`).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ brew install bats-core
 bats tests/*.bats
 ```
 
-Tests cover: `parse_go_mod` replace-directive ordering, TruffleHog invocation modes (including allowlist suppression), gate evaluation logic, golden orchestration contracts (SKILL.md structural integrity, PROVIDERS.md correctness, SEVERITY.md contract), and all static analyzer scripts (eslint, hadolint, kube-linter, phpcs, phpstan, tflint). All 150 tests are offline (no network, no Claude invocation).
+Tests cover: `parse_go_mod` replace-directive ordering, TruffleHog invocation modes (including allowlist suppression), gate evaluation logic, golden orchestration contracts (SKILL.md structural integrity, PROVIDERS.md correctness, SEVERITY.md contract), and all static analyzer scripts (eslint, hadolint, kube-linter, phpcs, phpstan, tflint). All 184 tests are offline (no network, no Claude invocation).
 
 ## Acknowledgments
 

--- a/docs/token-efficiency.md
+++ b/docs/token-efficiency.md
@@ -50,16 +50,14 @@ Run this skill on **Sonnet** — the orchestrator does structured workflow coord
 
 ## Token utilization table
 
-Phase 5 always prints a per-agent breakdown of input/output/cache tokens and estimated USD cost, so you can see where budget is going without running `/cost`:
+Phase 5 always prints a per-agent breakdown of tokens, tool calls, and estimated USD cost, so you can see where budget is going without running `/cost`:
 
 | Column | Description |
 |--------|-------------|
 | Agent | Agent name |
-| Model | Resolved model (e.g., "Sonnet 4.6") |
-| Input | Input tokens consumed |
-| Output | Output tokens generated |
-| Cache Read | Tokens read from prompt cache (when active) |
-| Total | Combined token count |
-| Est. Cost | Estimated cost at public list prices |
+| Model | Resolved model (e.g., "Sonnet", "Opus", "Haiku") |
+| Tokens | Combined token count (`subagent_tokens`) — the Agent tool returns only a single total per agent, with no input/output/cache breakdown |
+| Tools | Number of tool calls the agent made |
+| Est. Cost | Estimated cost from a blended per-model rate (Opus ~$45/M tokens, Sonnet ~$9/M, Haiku ~$0.8/M) |
 
-Costs use public list prices and do not reflect enterprise discounts.
+Costs are blended-rate estimates, not public list prices — the underlying token total doesn't distinguish input from output from cache reads, so an exact list-price calculation isn't possible from what the Agent tool returns. Run `/cost` for exact figures.

--- a/skills/comprehensive-review/scripts/run-phpcs.sh
+++ b/skills/comprehensive-review/scripts/run-phpcs.sh
@@ -54,6 +54,8 @@ if [[ ${#PHP_FILES[@]} -eq 0 ]]; then
   exit 0
 fi
 
+PHPCS_STANDARD="PSR12"
+
 if [[ -n "${PHPCS_MOCK_FILE:-}" ]]; then
   if [[ ! -r "$PHPCS_MOCK_FILE" ]]; then
     echo "WARNING: PHPCS_MOCK_FILE '${PHPCS_MOCK_FILE}' is not readable." >&2
@@ -63,7 +65,6 @@ if [[ -n "${PHPCS_MOCK_FILE:-}" ]]; then
   PHPCS_OUTPUT=$(cat "$PHPCS_MOCK_FILE")
 else
   # Select standard: prefer Drupal,DrupalPractice (via drupal/coder), fall back to PSR12
-  PHPCS_STANDARD="PSR12"
   if phpcs -i 2>/dev/null | grep -q "Drupal"; then
     PHPCS_STANDARD="Drupal,DrupalPractice"
   fi


### PR DESCRIPTION
## Summary

Pre-release audit of the already-merged v1.13.0 "Human in the Middle" draft-review-mode feature (PR #129). Dates the CHANGELOG entry and documents the hardening fixes that landed on that branch after the original feature commit, corrects a stale test count (150 -> 184) in README.md and CLAUDE.md, corrects a stale token-utilization-table description in docs/token-efficiency.md, and fixes a pre-existing (unrelated) bug in run-phpcs.sh where `$PHPCS_STANDARD` was unbound under `set -euo pipefail` on the mock/offline test path -- silently discarding phpcs findings whenever that path ran, including every bats test invocation.

**Type:** docs
**Effort:** 2/5 -- 5 files, ~35 lines, no runtime logic changes outside a 3-line variable-initialization fix.

## Walkthrough

| File | Change | Summary |
|---|---|---|
| CHANGELOG.md | Modified | Dates the 1.13.0 entry (was "Unreleased"); adds a Fixed section documenting the hardening commits (`3e84c32`, `d05d8d5`, `7af3ef1`, `d6f16fe`, `4855e97`); adds a Known Limitations note that GitLab's draft/read-back path was not live-E2E-tested this release |
| CLAUDE.md, README.md | Modified | Corrects stale "150 tests" to the actual current count of 184 |
| docs/token-efficiency.md | Modified | Corrects the Phase 5 token-utilization-table description (was documenting a 7-column input/output/cache-read format at public list prices; actual format is 5 columns using blended per-model rates) to match what SKILL.md actually implements |
| skills/comprehensive-review/scripts/run-phpcs.sh | Modified | Fixes unbound `$PHPCS_STANDARD` on the mock/offline code path -- it was only initialized inside the live-`phpcs` branch, so the mock path (used by every bats test) hit an unbound-variable failure under `set -euo pipefail`, silently swallowed by the script's own fallback |

## Review Findings

**Overall Risk:** Low -- zero findings from all four review agents (pr-summarizer, code-reviewer, architecture-reviewer, security-reviewer), each independently verifying the phpcs fix is correct and complete, and that the doc corrections match the actual current codebase state.

### Test results

`bats tests/*.bats`: 183 passing. One pre-existing, environment-specific failure (`kube-linter: binary missing returns empty array`) unrelated to this diff -- caused by `kube-linter` being installed locally via Homebrew in this environment, not by anything this diff touches.

### Positive observations

- The `run-phpcs.sh` fix is minimal and correct: hoists a hardcoded-constant initialization rather than duplicating it, and preserves the live-path Drupal-vs-PSR12 detection logic unchanged.
- The CHANGELOG's Fixed section is unusually candid about verification limits (downgrades an "author-only visible" claim to an unverified assumption; documents that GitLab's path wasn't live-tested).